### PR TITLE
fix: update query logic and rename variables for clarity

### DIFF
--- a/utility_billing/utility_billing/doctype/meter_reading/meter_reading.js
+++ b/utility_billing/utility_billing/doctype/meter_reading/meter_reading.js
@@ -134,7 +134,6 @@ function update_meter_number_query(frm) {
 			frm.fields_dict["items"].grid.get_field("meter_number").get_query = function () {
 				return {
 					filters: {
-						status: "Active",
 						name: ["in", closedWarrantySerials],
 					},
 				};

--- a/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.js
+++ b/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.js
@@ -565,7 +565,7 @@ async function addActionButtons(frm) {
 
 			const contractName = contract?.message?.name || null;
 			const depositName = deposit?.message?.name || null;
-			const creteContract =
+			const canCreateContract =
 				!contractName &&
 				(!settings?.require_deposit_before_contract_creation || depositName);
 
@@ -577,7 +577,7 @@ async function addActionButtons(frm) {
 				__("Create")
 			);
 
-			if (creteContract) {
+			if (canCreateContract) {
 				frm.add_custom_button(
 					__("Contract"),
 					function () {


### PR DESCRIPTION

This PR improves the readability and correctness of the utility billing module by:

* Removing an unnecessary query filter
* Fixing a typo in a variable name to better reflect its purpose

---

### ✅ Code Clarity Improvements

* **Renamed:**
  `creteContract` ➡️ `canCreateContract`
  For enhanced readability and accuracy

* **Location:**
  [`[utility_service_request.js](diffhunk://#diff-a2a122f96a483b25929b8c442f698f2b13ba0d2fe075bacb9bdc726603ce89cfL568-R568)`](diffhunk://#diff-a2a122f96a483b25929b8c442f698f2b13ba0d2fe075bacb9bdc726603ce89cfL568-R568)

* **Context:**
  Updated in both the variable declaration and in its usage within a conditional statement
  [\[1\]](diffhunk://#diff-a2a122f96a483b25929b8c442f698f2b13ba0d2fe075bacb9bdc726603ce89cfL568-R568)
  [\[2\]](diffhunk://#diff-a2a122f96a483b25929b8c442f698f2b13ba0d2fe075bacb9bdc726603ce89cfL580-R580)

---

### 🔍 Query Refinement

* **File:** [`[meter_reading.js](diffhunk://#diff-42300b2379b8f1c30af64ca049f894d5d5015b649bfaaf545d2e9487af608a11L137)`](diffhunk://#diff-42300b2379b8f1c30af64ca049f894d5d5015b649bfaaf545d2e9487af608a11L137)

* **Change:**
  Removed the `status: "Active"` filter from the `meter_number` query

* **Reason:**
  Simplifies the query logic by avoiding redundant filtering and ensures broader applicability in use cases where status filtering isn't required
