### PR TITLE
Enhancement/Add Flexible Auto-Repeat Support for Sales Documents (Service Request)

### DIFF
--- a/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.js
+++ b/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.js
@@ -718,17 +718,22 @@ function configure_dialog(dialog, frm) {
 }
 
 async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false) {
+	// Fetch customer details to pre-fill the dialog
 	const customer = await frappe.db.get_value("Customer", frm.doc.customer, ["customer_name"]);
-	const today = frappe.datetime.get_today();
+	const today = frappe.datetime.get_today(); // Get today's date
+
+	// Determine the title of the dialog based on document type
 	const title =
 		docType === "Sales Order" ? __("Create Sales Order") : __("Create Sales Invoice");
+	// Determine the primary action method to call on form submission
 	const primaryActionMethod =
 		docType === "Sales Order"
 			? "utility_billing.utility_billing.doctype.utility_service_request.utility_service_request.create_sales_order_doc"
 			: "utility_billing.utility_billing.doctype.utility_service_request.utility_service_request.create_sales_invoice_doc";
 
+	// Define the fields for the dialog
 	const fields = [
-		...get_customer_section_fields(frm, customer?.message?.customer_name),
+		...get_customer_section_fields(frm, customer?.message?.customer_name), // Customer-related fields
 		{
 			fieldname: "transaction_details_section",
 			fieldtype: "Section Break",
@@ -756,16 +761,18 @@ async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false)
 		},
 	];
 
+	// Add due_date field specifically for Sales Invoice
 	if (docType === "Sales Invoice") {
 		fields.push({
 			fieldname: "due_date",
 			label: __("Due Date"),
 			fieldtype: "Date",
-			default: frappe.datetime.add_days(today, 30),
+			default: frappe.datetime.add_days(today, 30), // Default due date to 30 days from today
 			reqd: 1,
 		});
 	}
 
+	// Add fields for Property and Auto Repeat settings
 	fields.push(
 		{
 			fieldname: "property_auto_repeat_section", // New section for Property and Auto Repeat
@@ -778,32 +785,73 @@ async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false)
 			label: __("Property"),
 			fieldtype: "Link",
 			options: "Utility Property",
+			// Custom query to filter properties based on `requested_properties` in the parent form
 			get_query: () => {
 				const properties = (frm.doc.requested_properties || [])
 					.map((p) => p.utility_property)
 					.filter(Boolean);
+
+				// If no properties in requested_properties, don't filter
+				if (!properties.length) {
+					return {};
+				}
+
 				return {
 					filters: [["name", "in", properties]],
 				};
 			},
+			// Logic to execute when the utility_property field changes
 			change: function () {
-				let selected_value = this.get_value();
-				let items = dialog.get_value("items_table") || [];
+				let selected_value = this.get_value(); // Get the currently selected property
+				let items = dialog.get_value("items_table") || []; // Get current items in the table
 
-				let frequency = null;
-				frm.doc.requested_properties.forEach((property) => {
-					if (property.utility_property === selected_value) {
-						frequency = property.frequency;
-					}
-				});
+				let property_line = null;
+				if (selected_value) {
+					// Find the corresponding property line in the parent form's requested_properties
+					property_line = (frm.doc.requested_properties || []).find(
+						(prop) => prop.utility_property === selected_value
+					);
+				}
 
-				items.forEach((row) => {
-					row.utility_property = selected_value;
-					row.frequency = frequency;
-				});
+				// Update items with property and frequency if a matching property line is found
+				if (property_line) {
+					items.forEach((row) => {
+						row.utility_property = selected_value;
+						row.frequency = property_line.frequency; // Set frequency from property line
 
-				dialog.set_value("items_table", items);
+						// Set adjustment_rule if it exists in the property line
+						if (property_line.adjustment_rule) {
+							dialog.set_value("adjustment_rule", property_line.adjustment_rule);
+						} // Set start_date if it exists in the property line
+						if (property_line.start_date) {
+							dialog.set_value("start_date", property_line.start_date);
+						} // Set end_date if it exists in the property line
+						if (property_line.end_date) {
+							dialog.set_value("end_date", property_line.end_date);
+						}
+					});
+				} else {
+					// Clear property and frequency from items if no matching property line
+					items.forEach((row) => {
+						row.utility_property = selected_value;
+						row.frequency = null;
+					});
+					// Clear auto-repeat dates if no property is selected or matched
+					dialog.set_value("start_date", null);
+					dialog.set_value("end_date", null);
+				}
+
+				dialog.set_value("items_table", items); // Update the items table in the dialog
 			},
+		},
+		{
+			fieldname: "adjustment_rule",
+			label: __("Billing Adjustment Rule"),
+			fieldtype: "Link",
+			options: "Billing Adjustment Rule",
+			depends_on: "eval:doc.enable_auto_repeat==1",
+			mandatory_depends_on: "eval:doc.enable_auto_repeat==1",
+			description: __("Rule defining how billing amounts will adjust over time"),
 		},
 		{
 			fieldname: "col_break_auto_repeat", // Column Break for 2 columns in this new section
@@ -814,6 +862,50 @@ async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false)
 			label: __("Enable Auto Repeat"),
 			fieldtype: "Check",
 			default: 0,
+			description: __("Enable recurring billing for this document"),
+			change: function () {
+				// When enable_auto_repeat changes, update the visibility and mandatory status of date fields
+				const isChecked = this.get_value();
+				dialog.toggle_display(["start_date", "end_date", "adjustment_rule"], isChecked);
+				dialog.set_df_property("start_date", "reqd", isChecked);
+				dialog.set_df_property("end_date", "reqd", isChecked);
+				dialog.set_df_property("adjustment_rule", "reqd", isChecked);
+
+				// If enabled, and a property is selected, auto-set start date
+				if (isChecked && dialog.get_value("utility_property")) {
+					const selectedProperty = dialog.get_value("utility_property");
+					const property_line = (frm.doc.requested_properties || []).find(
+						(prop) => prop.utility_property === selectedProperty
+					);
+
+					if (property_line) {
+						const startDate = today;
+						dialog.set_value("start_date", startDate);
+						// No automatic end date calculation without calculateEndDate
+					}
+				} else if (!isChecked) {
+					// If disabled, clear the dates
+					dialog.set_value("start_date", null);
+					dialog.set_value("end_date", null);
+				}
+			},
+		},
+		{
+			fieldname: "start_date",
+			label: __("Recurring Billing Start Date"),
+			fieldtype: "Date",
+			default: today, // Default start date to today
+			depends_on: "eval:doc.enable_auto_repeat==1", // Only show if auto-repeat is enabled
+			mandatory_depends_on: "eval:doc.enable_auto_repeat==1", // Mandatory if auto-repeat is enabled
+			description: __("Date when recurring billing will begin"),
+		},
+		{
+			fieldname: "end_date",
+			label: __("Recurring Billing End Date"),
+			fieldtype: "Date",
+			depends_on: "eval:doc.enable_auto_repeat==1", // Only show if auto-repeat is enabled
+			mandatory_depends_on: "eval:doc.enable_auto_repeat==1", // Mandatory if auto-repeat is enabled
+			description: __("Date when recurring billing will stop"),
 		},
 		{
 			fieldname: "items_table_section", // New section for Items Table
@@ -825,14 +917,15 @@ async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false)
 			fieldname: "items_table",
 			fieldtype: "Table",
 			label: __("Items"),
-			fields: get_item_table_fields(frm),
-			data: prepare_items_data(frm),
-			cannot_add_rows: !allowAdditionalRows,
+			fields: get_item_table_fields(frm), // Get item table field definitions
+			data: prepare_items_data(frm), // Prepare initial data for the item table
+			cannot_add_rows: !allowAdditionalRows, // Prevent adding rows if not allowed
+			// Custom handler for when a row in the table is edited (opens a row modal)
 			on_edit: function (row, row_modal) {
-				// Hide parent dialog
+				// Hide parent dialog temporarily to avoid overlap
 				dialog.$wrapper.addClass("frappe-modal-hidden");
 
-				// Ensure row modal has a higher z-index
+				// Ensure row modal has a higher z-index to be on top
 				row_modal.$wrapper.css("z-index", 1052);
 
 				// On close of the row modal, show the parent dialog again
@@ -843,11 +936,14 @@ async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false)
 		}
 	);
 
+	// Create a new Frappe UI Dialog instance
 	const dialog = new frappe.ui.Dialog({
 		title: title,
 		fields: fields,
 		primary_action_label: __("Create"),
+		// Primary action to be executed when the "Create" button is clicked
 		primary_action: function (values) {
+			// Map table data to the required format for the API call
 			const items = values.items_table.map((row) => ({
 				// Include all necessary fields from the dialog item rows
 				item_code: row.item_code,
@@ -857,20 +953,24 @@ async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false)
 				warehouse: row.warehouse,
 				utility_property: row.utility_property,
 				frequency: row.frequency, // Ensure frequency is passed if applicable
-				// Add any other relevant fields from the item table
-				...row,
+				...row, // Include any other relevant fields from the item table
 			}));
 
+			// Prepare arguments for the API call
 			const args = {
-				docname: frm.doc.name,
+				docname: frm.doc.name, // Parent document name
 				items: items,
 				customer: values.customer,
 				customer_name: values.customer_name,
 				company: values.company,
 				property: values.utility_property, // Pass the selected property
-				enable_auto_repeat: values.enable_auto_repeat, // Always pass the checkbox value
+				enable_auto_repeat: values.enable_auto_repeat, // Pass the checkbox value
+				adjustment_rule: values.adjustment_rule, // Pass the adjustment rule if auto repeat is enabled
+				start_date: values.start_date, // Pass the start date
+				end_date: values.end_date, // Pass the end date
 			};
 
+			// Add transaction-specific dates based on document type
 			if (docType === "Sales Order") {
 				args.transaction_date = values.posting_date;
 			} else {
@@ -878,12 +978,14 @@ async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false)
 				args.due_date = values.due_date;
 			}
 
+			// Make the API call to create the document
 			frappe.call({
 				method: primaryActionMethod,
 				args: args,
 				callback: function (response) {
-					dialog.hide();
+					dialog.hide(); // Hide the dialog after the call
 					if (response.message) {
+						// Show success message and navigate to the newly created document
 						frappe.show_alert({
 							message: `${docType} created successfully!`,
 							indicator: "green",
@@ -895,7 +997,14 @@ async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false)
 		},
 	});
 
+	// Configure the dialog after initialization (e.g., initial field visibility)
 	configure_dialog(dialog, frm);
+
+	// Manually trigger initial visibility for auto-repeat fields based on default value
+	dialog.toggle_display(
+		["start_date", "end_date", "adjustment_rule"],
+		dialog.get_value("enable_auto_repeat")
+	);
 }
 
 // Update the action buttons to use the new common modal function

--- a/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.js
+++ b/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.js
@@ -521,6 +521,384 @@ function open_bom_creation_modal(frm) {
 	modal.show();
 }
 
+// Common function to get customer section fields with 2 columns
+function get_customer_section_fields(frm, customerName) {
+	return [
+		{
+			fieldname: "customer_section",
+			fieldtype: "Section Break",
+			label: __("Customer Details"),
+			collapsible: 0,
+		},
+		{
+			fieldname: "customer",
+			label: __("Customer"),
+			fieldtype: "Link",
+			options: "Customer",
+			default: frm.doc.customer,
+			read_only: 1,
+		},
+		{
+			fieldname: "col_break_customer", // Column Break for 2 columns
+			fieldtype: "Column Break",
+		},
+		{
+			fieldname: "customer_name",
+			label: __("Customer Name"),
+			fieldtype: "Data",
+			default: customerName,
+			read_only: 1,
+		},
+	];
+}
+
+// Common function to get item table fields configuration dynamically from the form
+function get_item_table_fields(frm) {
+	const child_table = frm.fields_dict["items"];
+	const child_fields = child_table.grid.docfields;
+
+	// Filter and map fields with custom logic
+	const dialog_item_fields = child_fields.map((field) => {
+		let config = {
+			label: field.label,
+			fieldname: field.fieldname,
+			fieldtype: field.fieldtype,
+			in_list_view: field.in_list_view,
+			read_only: field.read_only,
+			depends_on: field.depends_on,
+			options: field.options,
+			reqd: field.reqd,
+			default: field.default,
+		};
+
+		// Add onchange handlers
+		if (field.fieldname === "qty" || field.fieldname === "rate") {
+			config.onchange = function () {
+				calculate_row_amount(this.grid_row);
+			};
+		}
+
+		if (field.fieldname === "item_code") {
+			config.onchange = function () {
+				const row = this.grid_row;
+				if (this.value) {
+					frappe.call({
+						method: "frappe.client.get_value",
+						args: {
+							doctype: "Item",
+							fieldname: ["item_name", "standard_rate"],
+							filters: { name: this.value },
+						},
+						callback: (r) => {
+							if (!r.exc) {
+								row.doc.item_name = r.message.item_name;
+								row.doc.rate = r.message.standard_rate;
+								calculate_row_amount(row);
+								// Note: refresh_field("items_table") might not work directly on dialog table.
+								// You might need to refresh the grid if it's a custom table.
+								row.grid.refresh();
+							}
+						},
+					});
+				}
+			};
+		}
+
+		// Ensure utility_property is visible in the list view
+		if (field.fieldname === "utility_property") {
+			config.in_list_view = 1;
+			config.reqd = 1;
+		}
+
+		return config;
+	});
+
+	return dialog_item_fields;
+}
+
+// Common function to prepare items data dynamically based on allowed fields
+function prepare_items_data(frm) {
+	const child_table = frm.fields_dict["items"];
+	const child_fields = child_table.grid.docfields;
+	const allowedFields = child_fields.map((f) => f.fieldname);
+
+	return frm.doc.items.map((item) => {
+		const qty = item.qty || 1;
+		const rate = item.rate || 0;
+
+		// Original data with only the necessary fields
+		const fullData = {
+			name: item.name,
+			item_code: item.item_code,
+			rate: rate,
+			amount: flt(rate * qty),
+			qty: qty,
+			warehouse: item.warehouse || frappe.defaults.get_user_default("Warehouse"),
+			...item, // Include all other fields from the original item
+		};
+
+		// Filter out fields not in child table fields
+		return Object.fromEntries(
+			Object.entries(fullData).filter(([key]) => allowedFields.includes(key))
+		);
+	});
+}
+
+// Common function to calculate row amount
+function calculate_row_amount(row) {
+	const qty = parseFloat(row.doc.qty) || 0;
+	const rate = parseFloat(row.doc.rate) || 0;
+	row.doc.amount = parseFloat(qty * rate);
+	row.grid.refresh();
+}
+
+// Common function to configure dialog properties
+function configure_dialog(dialog, frm) {
+	dialog.fields_dict["items_table"].grid.get_field("utility_property").get_query = function () {
+		const selected_properties = frm.get_selected_utility_properties?.() || [];
+
+		return {
+			filters: {
+				name: ["in", selected_properties.length ? selected_properties : ["__none"]],
+			},
+		};
+	};
+
+	dialog.$wrapper.find(".modal-dialog").css("max-width", "max-content");
+	dialog.$wrapper.find(".modal-content").css("width", "1000px");
+	dialog.show();
+
+	const appliedStyleMap = new WeakMap();
+
+	const observer = new MutationObserver(() => {
+		const openGridRow = document.querySelector(".grid-row.grid-row-open");
+
+		if (openGridRow && !openGridRow.classList.contains("custom-grid-modal")) {
+			openGridRow.classList.add("custom-grid-modal");
+
+			const customStyles = {
+				background: "#fff",
+				zIndex: "1051",
+				padding: "50px",
+				position: "fixed",
+				top: "60px",
+				left: "50%",
+				transform: "translateX(-50%)",
+				maxWidth: "900px",
+				width: "100%",
+				maxHeight: "90vh",
+				overflowY: "auto",
+				overflowX: "hidden",
+				opacity: "1",
+				pointerEvents: "auto",
+				boxShadow: "0 0 5px rgba(0, 0, 0, 0.3)",
+				borderRadius: "8px",
+			};
+
+			appliedStyleMap.set(openGridRow, customStyles);
+			Object.assign(openGridRow.style, customStyles);
+		}
+
+		document.querySelectorAll(".custom-grid-modal").forEach((el) => {
+			if (!el.classList.contains("grid-row-open")) {
+				el.classList.remove("custom-grid-modal");
+
+				const appliedStyles = appliedStyleMap.get(el);
+				if (appliedStyles) {
+					for (const prop in appliedStyles) {
+						el.style[prop] = "";
+					}
+					appliedStyleMap.delete(el);
+				}
+			}
+		});
+	});
+
+	observer.observe(document.body, { childList: true, subtree: true });
+}
+
+async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false) {
+	const customer = await frappe.db.get_value("Customer", frm.doc.customer, ["customer_name"]);
+	const today = frappe.datetime.get_today();
+	const title =
+		docType === "Sales Order" ? __("Create Sales Order") : __("Create Sales Invoice");
+	const primaryActionMethod =
+		docType === "Sales Order"
+			? "utility_billing.utility_billing.doctype.utility_service_request.utility_service_request.create_sales_order_doc"
+			: "utility_billing.utility_billing.doctype.utility_service_request.utility_service_request.create_sales_invoice_doc";
+
+	const fields = [
+		...get_customer_section_fields(frm, customer?.message?.customer_name),
+		{
+			fieldname: "transaction_details_section",
+			fieldtype: "Section Break",
+			label: __(""),
+			collapsible: 0,
+		},
+		{
+			fieldname: "posting_date", // Use posting_date for both for consistency, label will change
+			label: docType === "Sales Order" ? __("Date") : __("Posting Date"),
+			fieldtype: "Date",
+			default: today,
+			reqd: 1,
+		},
+		{
+			fieldname: "col_break_transaction", // Column Break for 2 columns in transaction details
+			fieldtype: "Column Break",
+		},
+		{
+			fieldname: "company",
+			label: __("Company"),
+			fieldtype: "Link",
+			options: "Company",
+			default: frappe.defaults.get_user_default("Company"),
+			reqd: 1,
+		},
+	];
+
+	if (docType === "Sales Invoice") {
+		fields.push({
+			fieldname: "due_date",
+			label: __("Due Date"),
+			fieldtype: "Date",
+			default: frappe.datetime.add_days(today, 30),
+			reqd: 1,
+		});
+	}
+
+	fields.push(
+		{
+			fieldname: "property_auto_repeat_section", // New section for Property and Auto Repeat
+			fieldtype: "Section Break",
+			label: __(""),
+			collapsible: 0,
+		},
+		{
+			fieldname: "utility_property",
+			label: __("Property"),
+			fieldtype: "Link",
+			options: "Utility Property",
+			get_query: () => {
+				const properties = (frm.doc.requested_properties || [])
+					.map((p) => p.utility_property)
+					.filter(Boolean);
+				return {
+					filters: [["name", "in", properties]],
+				};
+			},
+			change: function () {
+				let selected_value = this.get_value();
+				let items = dialog.get_value("items_table") || [];
+
+				let frequency = null;
+				frm.doc.requested_properties.forEach((property) => {
+					if (property.utility_property === selected_value) {
+						frequency = property.frequency;
+					}
+				});
+
+				items.forEach((row) => {
+					row.utility_property = selected_value;
+					row.frequency = frequency;
+				});
+
+				dialog.set_value("items_table", items);
+			},
+		},
+		{
+			fieldname: "col_break_auto_repeat", // Column Break for 2 columns in this new section
+			fieldtype: "Column Break",
+		},
+		{
+			fieldname: "enable_auto_repeat",
+			label: __("Enable Auto Repeat"),
+			fieldtype: "Check",
+			default: 0,
+		},
+		{
+			fieldname: "items_table_section", // New section for Items Table
+			fieldtype: "Section Break",
+			label: __(""),
+			collapsible: 0,
+		},
+		{
+			fieldname: "items_table",
+			fieldtype: "Table",
+			label: __("Items"),
+			fields: get_item_table_fields(frm),
+			data: prepare_items_data(frm),
+			cannot_add_rows: !allowAdditionalRows,
+			on_edit: function (row, row_modal) {
+				// Hide parent dialog
+				dialog.$wrapper.addClass("frappe-modal-hidden");
+
+				// Ensure row modal has a higher z-index
+				row_modal.$wrapper.css("z-index", 1052);
+
+				// On close of the row modal, show the parent dialog again
+				row_modal.onhide = () => {
+					dialog.$wrapper.removeClass("frappe-modal-hidden");
+				};
+			},
+		}
+	);
+
+	const dialog = new frappe.ui.Dialog({
+		title: title,
+		fields: fields,
+		primary_action_label: __("Create"),
+		primary_action: function (values) {
+			const items = values.items_table.map((row) => ({
+				// Include all necessary fields from the dialog item rows
+				item_code: row.item_code,
+				qty: row.qty,
+				rate: row.rate,
+				amount: row.amount,
+				warehouse: row.warehouse,
+				utility_property: row.utility_property,
+				frequency: row.frequency, // Ensure frequency is passed if applicable
+				// Add any other relevant fields from the item table
+				...row,
+			}));
+
+			const args = {
+				docname: frm.doc.name,
+				items: items,
+				customer: values.customer,
+				customer_name: values.customer_name,
+				company: values.company,
+				property: values.utility_property, // Pass the selected property
+				enable_auto_repeat: values.enable_auto_repeat, // Always pass the checkbox value
+			};
+
+			if (docType === "Sales Order") {
+				args.transaction_date = values.posting_date;
+			} else {
+				args.posting_date = values.posting_date;
+				args.due_date = values.due_date;
+			}
+
+			frappe.call({
+				method: primaryActionMethod,
+				args: args,
+				callback: function (response) {
+					dialog.hide();
+					if (response.message) {
+						frappe.show_alert({
+							message: `${docType} created successfully!`,
+							indicator: "green",
+						});
+						frappe.set_route("Form", docType, response.message);
+					}
+				},
+			});
+		},
+	});
+
+	configure_dialog(dialog, frm);
+}
+
+// Update the action buttons to use the new common modal function
 async function addActionButtons(frm) {
 	const currentStatus = frm.doc.request_status;
 
@@ -573,7 +951,7 @@ async function addActionButtons(frm) {
 			frm.add_custom_button(
 				__("Sales Order / Deposit"),
 				function () {
-					showSalesOrderModal(frm, enableExtraRows);
+					showSalesDocumentModal(frm, "Sales Order", enableExtraRows);
 				},
 				__("Create")
 			);
@@ -605,7 +983,7 @@ async function addActionButtons(frm) {
 				frm.add_custom_button(
 					__("Sales Invoice"),
 					function () {
-						showSalesInvoiceModal(frm, enableExtraRows);
+						showSalesDocumentModal(frm, "Sales Invoice", enableExtraRows);
 					},
 					__("Create")
 				);
@@ -689,443 +1067,6 @@ async function addActionButtons(frm) {
 			__("Create")
 		);
 	}
-}
-// Common function to get item table fields configuration dynamically from the form
-function get_item_table_fields(frm) {
-	const child_table = frm.fields_dict["items"];
-	const child_fields = child_table.grid.docfields;
-
-	// Filter and map fields with custom logic
-	const dialog_item_fields = child_fields.map((field) => {
-		let config = {
-			label: field.label,
-			fieldname: field.fieldname,
-			fieldtype: field.fieldtype,
-			in_list_view: field.in_list_view,
-			read_only: field.read_only,
-			depends_on: field.depends_on,
-			options: field.options,
-			reqd: field.reqd,
-			default: field.default,
-		};
-
-		// Add onchange handlers
-		if (field.fieldname === "qty" || field.fieldname === "rate") {
-			config.onchange = function () {
-				calculate_row_amount(this.grid_row);
-			};
-		}
-
-		if (field.fieldname === "item_code") {
-			config.onchange = function () {
-				const row = this.grid_row;
-				if (this.value) {
-					frappe.call({
-						method: "frappe.client.get_value",
-						args: {
-							doctype: "Item",
-							fieldname: ["item_name", "standard_rate"],
-							filters: { name: this.value },
-						},
-						callback: (r) => {
-							if (!r.exc) {
-								row.doc.item_name = r.message.item_name;
-								row.doc.rate = r.message.standard_rate;
-								calculate_row_amount(row);
-								refresh_field("items_table");
-							}
-						},
-					});
-				}
-			};
-		}
-
-		// Ensure utility_property is visible in the list view
-		if (field.fieldname === "utility_property") {
-			config.in_list_view = 1;
-			config.reqd = 1;
-		}
-
-		return config;
-	});
-
-	return dialog_item_fields;
-}
-
-// Common function to prepare items data dynamically based on allowed fields
-function prepare_items_data(frm) {
-	const child_table = frm.fields_dict["items"];
-	const child_fields = child_table.grid.docfields;
-	const allowedFields = child_fields.map((f) => f.fieldname);
-
-	return frm.doc.items.map((item) => {
-		const qty = item.qty || 1;
-		const rate = item.rate || 0;
-
-		// Original data with only the necessary fields
-		const fullData = {
-			name: item.name,
-			item_code: item.item_code,
-			rate: rate,
-			amount: flt(rate * qty),
-			qty: qty,
-			warehouse: item.warehouse || frappe.defaults.get_user_default("Warehouse"),
-			...item, // Include all other fields from the original item
-		};
-
-		// Filter out fields not in child table fields
-		return Object.fromEntries(
-			Object.entries(fullData).filter(([key]) => allowedFields.includes(key))
-		);
-	});
-}
-
-// Common function to calculate row amount
-function calculate_row_amount(row) {
-	const qty = parseFloat(row.doc.qty) || 0;
-	const rate = parseFloat(row.doc.rate) || 0;
-	row.doc.amount = parseFloat(qty * rate);
-	row.grid.refresh();
-}
-
-// Common function for customer section fields
-function get_customer_section_fields(frm, customerName) {
-	return [
-		{
-			fieldname: "customer_section",
-			fieldtype: "Section Break",
-			label: __("Customer Details"),
-			collapsible: 0,
-		},
-		{
-			fieldname: "customer",
-			label: __("Customer"),
-			fieldtype: "Link",
-			options: "Customer",
-			default: frm.doc.customer,
-			read_only: 1,
-		},
-		{
-			fieldname: "customer_name",
-			label: __("Customer Name"),
-			fieldtype: "Data",
-			default: customerName,
-			read_only: 1,
-		},
-		{
-			fieldname: "col_break",
-			fieldtype: "Column Break",
-		},
-	];
-}
-function configure_dialog(dialog, frm) {
-	dialog.fields_dict["items_table"].grid.get_field("utility_property").get_query = function () {
-		const selected_properties = frm.get_selected_utility_properties?.() || [];
-
-		return {
-			filters: {
-				name: ["in", selected_properties.length ? selected_properties : ["__none"]],
-			},
-		};
-	};
-
-	dialog.$wrapper.find(".modal-dialog").css("max-width", "max-content");
-	dialog.$wrapper.find(".modal-content").css("width", "1000px");
-	dialog.show();
-
-	const appliedStyleMap = new WeakMap();
-
-	const observer = new MutationObserver(() => {
-		const openGridRow = document.querySelector(".grid-row.grid-row-open");
-
-		if (openGridRow && !openGridRow.classList.contains("custom-grid-modal")) {
-			openGridRow.classList.add("custom-grid-modal");
-
-			const customStyles = {
-				background: "#fff",
-				zIndex: "1051",
-				padding: "50px",
-				position: "fixed",
-				top: "60px",
-				left: "50%",
-				transform: "translateX(-50%)",
-				maxWidth: "900px",
-				width: "100%",
-				maxHeight: "90vh",
-				overflowY: "auto",
-				overflowX: "hidden",
-				opacity: "1",
-				pointerEvents: "auto",
-				boxShadow: "0 0 5px rgba(0, 0, 0, 0.3)",
-				borderRadius: "8px",
-			};
-
-			appliedStyleMap.set(openGridRow, customStyles);
-			Object.assign(openGridRow.style, customStyles);
-		}
-
-		document.querySelectorAll(".custom-grid-modal").forEach((el) => {
-			if (!el.classList.contains("grid-row-open")) {
-				el.classList.remove("custom-grid-modal");
-
-				const appliedStyles = appliedStyleMap.get(el);
-				if (appliedStyles) {
-					for (const prop in appliedStyles) {
-						el.style[prop] = "";
-					}
-					appliedStyleMap.delete(el);
-				}
-			}
-		});
-	});
-
-	observer.observe(document.body, { childList: true, subtree: true });
-}
-
-async function showSalesOrderModal(frm, allowAdditionalRows = false) {
-	const customer = await frappe.db.get_value("Customer", frm.doc.customer, ["customer_name"]);
-
-	const dialog = new frappe.ui.Dialog({
-		title: __("Create Sales Order"),
-		fields: [
-			...get_customer_section_fields(frm, customer?.message?.customer_name),
-			{
-				fieldname: "transaction_date",
-				label: __("Date"),
-				fieldtype: "Date",
-				default: frappe.datetime.get_today(),
-				reqd: 1,
-			},
-			{
-				fieldname: "company",
-				label: __("Company"),
-				fieldtype: "Link",
-				options: "Company",
-				default: frappe.defaults.get_user_default("Company"),
-				reqd: 1,
-			},
-			{
-				fieldname: "items_section",
-				fieldtype: "Section Break",
-				label: __("Select Items"),
-				collapsible: 0,
-			},
-
-			{
-				fieldname: "utility_property",
-				label: __("Property"),
-				fieldtype: "Link",
-				options: "Utility Property",
-				reqd: 1,
-				get_query: () => {
-					const properties = (frm.doc.requested_properties || [])
-						.map((p) => p.utility_property)
-						.filter(Boolean);
-					return {
-						filters: [["name", "in", properties]],
-					};
-				},
-				change: function () {
-					let selected_value = this.get_value();
-					let items = dialog.get_value("items_table") || [];
-
-					let frequency = null;
-					frm.doc.requested_properties.forEach((property) => {
-						if (property.utility_property === selected_value) {
-							frequency = property.frequency;
-						}
-					});
-
-					items.forEach((row) => {
-						row.utility_property = selected_value;
-						row.frequency = frequency;
-					});
-
-					dialog.set_value("frequency", frequency);
-					dialog.set_value("items_table", items);
-				},
-			},
-			{
-				fieldname: "items_table",
-				fieldtype: "Table",
-				label: __("Items"),
-				fields: get_item_table_fields(frm),
-				data: prepare_items_data(frm),
-				cannot_add_rows: !allowAdditionalRows,
-			},
-		],
-		primary_action_label: __("Create"),
-		primary_action: function (values) {
-			const items = values.items_table.map((row) => {
-				return {
-					name: row.name,
-					item_code: row.item_code,
-					qty: row.qty,
-					rate: row.rate,
-					amount: row.amount,
-					warehouse: row.warehouse,
-				};
-			});
-
-			frappe.call({
-				method: "utility_billing.utility_billing.doctype.utility_service_request.utility_service_request.create_sales_order_doc",
-				args: {
-					docname: frm.doc.name,
-					items: items,
-					customer: values.customer,
-					customer_name: values.customer_name,
-					transaction_date: values.transaction_date,
-					company: values.company,
-				},
-				callback: function (response) {
-					dialog.hide();
-					if (response.message) {
-						frappe.show_alert({
-							message: __("Sales Order created successfully!"),
-							indicator: "green",
-						});
-						frappe.set_route("Form", "Sales Order", response.message);
-					}
-				},
-			});
-		},
-	});
-
-	configure_dialog(dialog, frm);
-}
-
-async function showSalesInvoiceModal(frm, allowAdditionalRows = false) {
-	const customer = await frappe.db.get_value("Customer", frm.doc.customer, ["customer_name"]);
-	const today = frappe.datetime.get_today();
-
-	const dialog = new frappe.ui.Dialog({
-		title: __("Create Sales Invoice"),
-		fields: [
-			...get_customer_section_fields(frm, customer?.message?.customer_name),
-			{
-				fieldname: "posting_date",
-				label: __("Posting Date"),
-				fieldtype: "Date",
-				default: today,
-				reqd: 1,
-			},
-			{
-				fieldname: "company",
-				label: __("Company"),
-				fieldtype: "Link",
-				options: "Company",
-				default: frappe.defaults.get_user_default("Company"),
-				reqd: 1,
-			},
-			{
-				fieldname: "due_date",
-				label: __("Due Date"),
-				fieldtype: "Date",
-				default: frappe.datetime.add_days(today, 30),
-				reqd: 1,
-			},
-
-			// Items Section
-			{
-				fieldname: "items_section",
-				fieldtype: "Section Break",
-				label: __("Select Items"),
-				collapsible: 0,
-			},
-			{
-				fieldname: "utility_property",
-				label: __("Property"),
-				fieldtype: "Link",
-				options: "Utility Property",
-				reqd: 1,
-				get_query: () => {
-					const properties = (frm.doc.requested_properties || [])
-						.map((p) => p.utility_property)
-						.filter(Boolean);
-					return {
-						filters: [["name", "in", properties]],
-					};
-				},
-				change: function () {
-					let selected_value = this.get_value();
-					let items = dialog.get_value("items_table") || [];
-
-					let frequency = null;
-					frm.doc.requested_properties.forEach((property) => {
-						if (property.utility_property === selected_value) {
-							frequency = property.frequency;
-						}
-					});
-
-					items.forEach((row) => {
-						row.utility_property = selected_value;
-						row.frequency = frequency;
-					});
-
-					dialog.set_value("frequency", frequency);
-					dialog.set_value("items_table", items);
-				},
-			},
-			{
-				fieldname: "items_table",
-				fieldtype: "Table",
-				label: __("Items"),
-				fields: get_item_table_fields(frm),
-				data: prepare_items_data(frm),
-				cannot_add_rows: !allowAdditionalRows,
-				on_edit: function (row, row_modal) {
-					// Hide parent dialog
-					dialog.$wrapper.addClass("frappe-modal-hidden");
-
-					// Ensure row modal has a higher z-index
-					row_modal.$wrapper.css("z-index", 1052);
-
-					// On close of the row modal, show the parent dialog again
-					row_modal.onhide = () => {
-						dialog.$wrapper.removeClass("frappe-modal-hidden");
-					};
-				},
-			},
-		],
-		primary_action_label: __("Create"),
-		primary_action: function (values) {
-			const items = values.items_table.map((row) => ({
-				name: row.name,
-				item_code: row.item_code,
-				qty: row.qty,
-				rate: row.rate,
-				amount: row.amount,
-				warehouse: row.warehouse,
-				...row, // Include all other fields from the dialog
-			}));
-
-			frappe.call({
-				method: "utility_billing.utility_billing.doctype.utility_service_request.utility_service_request.create_sales_invoice_doc",
-				args: {
-					docname: frm.doc.name,
-					items: items,
-					customer: values.customer,
-					customer_name: values.customer_name,
-					posting_date: values.posting_date,
-					due_date: values.due_date,
-					company: values.company,
-					property: values.utility_property,
-				},
-				callback: function (response) {
-					dialog.hide();
-					if (response.message) {
-						frappe.show_alert({
-							message: __("Sales Invoice created successfully!"),
-							indicator: "green",
-						});
-						frappe.set_route("Form", "Sales Invoice", response.message);
-					}
-				},
-			});
-		},
-	});
-
-	configure_dialog(dialog, frm);
 }
 
 // Handle the response from the server

--- a/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.py
+++ b/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.py
@@ -20,7 +20,6 @@ class UtilityServiceRequest(Document):
         self.validate_contract_dates()
         self.validate_child_items()
 
-
     def before_update_after_submit(self):
         # Re-run validation logic when updating after submission
         self.validate_contract_dates()
@@ -29,7 +28,6 @@ class UtilityServiceRequest(Document):
     def set_customer_if_needed(self):
         if self.service_request_from == "Customer":
             self.customer = self.party_name
-
         
     def before_submit(self):
         self.status = "To Bill"
@@ -470,100 +468,126 @@ def get_utility_bill_structure_details(name):
         "dimensions": dimensions
     }
 
-
-
 @frappe.whitelist()
-def create_sales_order_doc(docname, items, customer=None, customer_name=None, transaction_date=None, company=None):
+def create_sales_order_doc(
+    docname: str,
+    items: list | str,
+    customer: str = None,
+    customer_name: str = None,
+    transaction_date: str = None,
+    company: str = None,
+    property: str = None,
+    enable_auto_repeat: str = None,
+    adjustment_rule: str = None,
+    start_date: str = None,
+    end_date: str = None
+):
     """
-    Create a Sales Order from Utility Service Request
-    
-    :param docname: Utility Service Request name
-    :param items: List of item dictionaries containing:
-        - item_code
-        - qty
-        - rate
-        - amount
-        - warehouse
-        - item_name (optional)
-    :param customer: Customer ID
-    :param transaction_date: Order date
-    :param company: Company 
+    Creates a Sales Order from a Utility Service Request and optionally creates an Auto Repeat document
+    with contract details stored in the Auto Repeat document.
+
+    :param docname: Utility Service Request name (str)
+    :param items: List of item dictionaries (list or JSON string)
+                  Each item dictionary must contain 'item_code', 'qty', and 'rate'.
+    :param customer: Customer ID (str, optional)
+    :param customer_name: Customer Name (str, optional)
+    :param transaction_date: Sales Order date (str, optional). If not provided,
+                             will attempt to use 'start_date' from utility property line.
+    :param company: Company (str, optional)
+    :param property: Utility Property name (str, optional)
+    :param enable_auto_repeat: Flag to enable auto repeat ('1' for true, others for false) (str, optional)
+    :param adjustment_rule: Name of the Billing Adjustment Rule to use (str, optional).
+                            If not provided, will attempt to use from utility property line.
+    :param start_date: Auto Repeat start date (str, optional). If not provided,
+                       will attempt to use 'start_date' from utility property line.
+    :param end_date: Auto Repeat end date (str, optional). If not provided,
+                     will attempt to use 'end_date' from utility property line.
+    :return: The name of the created Sales Order (str)
+    :raises frappe.ValidationError: If items are not valid or required fields are missing.
     """
     if isinstance(items, str):
         try:
             items = json.loads(items)
-        except Exception as e:
-            frappe.throw(f"Failed to parse items JSON: {e}")
+        except json.JSONDecodeError:
+            frappe.throw("Items must be a valid JSON string or a list of item dictionaries.")
 
     if not isinstance(items, list):
         frappe.throw("Items must be a list of item dictionaries.")
 
     for item in items:
+        if not isinstance(item, dict):
+            frappe.throw("Each item in the 'items' list must be a dictionary.")
         if not item.get("item_code"):
-            frappe.throw("Item Code is required for all items")
-        if not item.get("qty"):
-            frappe.throw("Quantity is required for all items")
-        if item.get("rate") is None:  
-            frappe.throw("Rate is required for all items")
+            frappe.throw("Item Code is required for all items.")
+        if item.get("qty") is None: 
+            frappe.throw("Quantity is required for all items.")
+        if item.get("rate") is None: 
+            frappe.throw("Rate is required for all items.")
 
     usr = frappe.get_doc("Utility Service Request", docname)
 
-    so = frappe.new_doc("Sales Order")
-    so.update({
-        "customer": customer or usr.customer,
-        "customer_name": customer_name,
-        "payment_terms_template": usr.payment_terms_template,
-        "tc_name": usr.tc_name,
-        "terms": usr.terms,
-        "company": company or usr.company or frappe.defaults.get_user_default("company"),
-        "transaction_date": transaction_date or nowdate(),
-        "delivery_date": add_days(transaction_date or nowdate(), 7),
+    property_line = None
+    if property:
+        property_line = next(
+            (prop for prop in usr.requested_properties
+             if prop.utility_property == property),
+            None
+        )
+
+    final_transaction_date = transaction_date or (property_line.start_date if property_line else None) or frappe.utils.nowdate()
+    final_start_date = start_date or (property_line.start_date if property_line else None) or frappe.utils.nowdate()
+    final_end_date = end_date or (property_line.end_date if property_line else None)
+
+    so = frappe.get_doc({
+        "doctype": "Sales Order",
         "utility_service_request": docname,
-        "territory": usr.territory,
-        "price_list": usr.price_list,
-        "currency": usr.currency or frappe.defaults.get_user_default("currency"),
-        "conversion_rate": 1.0,
-        "selling_price_list": usr.price_list,
-        "ignore_pricing_rule": 1,
+        "customer": customer or usr.customer,
+        "customer_name": customer_name or usr.customer_name, 
+        "transaction_date": final_transaction_date,
+        "delivery_date": add_days(final_transaction_date, 7),
+        "company": company or usr.company, 
+        "items": []
     })
-    
-    for item in items:
-        item_code = item.get("item_code")
 
-        item_line = {
-            "item_code": item_code,
-            "item_name": item.get("item_name") or frappe.db.get_value("Item", item_code, "item_name"),
-            "description": item.get("description") or frappe.db.get_value("Item", item_code, "description"),
-            "uom": item.get("uom") or frappe.db.get_value("Item", item_code, "stock_uom"),
-            "qty": float(item.get("qty", 0)),
-            "rate": float(item.get("rate", 0)),
-            "warehouse": item.get("warehouse") or frappe.defaults.get_user_default("warehouse"),
-            "conversion_factor": 1.0,
-        }
+    for item_data in items:
+        so.append("items", {
+            "item_code": item_data.get("item_code"),
+            "qty": item_data.get("qty"),
+            "rate": item_data.get("rate"),
+            "uom": item_data.get("uom"), 
+            "amount": item_data.get("amount") 
+        })
+    so.insert()
 
-        item_line["amount"] = float(item.get("amount", item_line["qty"] * item_line["rate"]))
+    if enable_auto_repeat == "1":
+        actual_adjustment_rule_name = adjustment_rule or (property_line.adjustment_rule if property_line else None)
 
-        for key, value in item.items():
-            if key not in item_line:
-                item_line[key] = value
+        if actual_adjustment_rule_name:
+            adjustment_rule_doc = frappe.get_doc("Billing Adjustment Rule", actual_adjustment_rule_name)
 
-        so.append("items", item_line)
+            auto_repeat_settings = {
+                "frequency": adjustment_rule_doc.frequency,
+                "start_date": final_start_date,
+                "end_date": final_end_date,
+                "utility_property": property,
+                "submit_on_creation": adjustment_rule_doc.submit_on_creation,
+                "repeat_on_day": adjustment_rule_doc.repeat_on_day,
+                "repeat_on_last_day": adjustment_rule_doc.repeat_on_last_day,
+                "repeat_on_days": adjustment_rule_doc.repeat_on_days,
+            }
 
-    so.insert(ignore_permissions=True)
-    
-    if frappe.db.get_single_value("Utility Billing Settings", "sales_order_creation_state") == "Submitted":
-        so.submit()
+            create_single_auto_repeat_with_contract_details(
+                so,
+                usr,
+                adjustment_rule_doc,
+                auto_repeat_settings
+            )
 
-    frappe.get_doc({
-        "doctype": "Comment",
-        "comment_type": "Info",
-        "reference_doctype": "Utility Service Request",
-        "reference_name": docname,
-        "content": f"Created Sales Order <a href='/app/sales-order/{so.name}'>{so.name}</a>"
-    }).insert(ignore_permissions=True)
+            add_transaction_comments(so, docname, auto_repeat_settings)
+        else:
+            frappe.msgprint("Auto Repeat not created: No adjustment rule specified for property.")
 
     return so.name
-
 
 @frappe.whitelist()
 def create_sales_invoice_doc(
@@ -660,7 +684,7 @@ def create_sales_invoice_doc(
     si.insert()
 
     if enable_auto_repeat == "1":
-        actual_adjustment_rule_name = adjustment_rule or property_line.adjustment_rule
+        actual_adjustment_rule_name = adjustment_rule or (property_line.adjustment_rule if property_line else None)
 
         if actual_adjustment_rule_name:
             adjustment_rule_doc = frappe.get_doc("Billing Adjustment Rule", actual_adjustment_rule_name)
@@ -689,30 +713,37 @@ def create_sales_invoice_doc(
 
     return si.name
 
-
-def add_transaction_comments(sales_invoice, usr_name, auto_repeat=None):
+def add_transaction_comments(transaction, usr_name, auto_repeat=None):
     """
     Add comprehensive comments to Utility Service Request and associated Utility Property
-    documenting the sales invoice creation and auto-repeat setup.
+    documenting the transaction creation and auto-repeat setup.
     
     Args:
-        sales_invoice (Sales Invoice): The created sales invoice document
+        transaction (Document): The created transaction document (Sales Order or Sales Invoice)
         usr_name (str): Name of the Utility Service Request
         auto_repeat (dict): Auto repeat configuration if applicable
     """
-    def create_comment_content(title, si, show_property=True, show_request_link=False):
+    def create_comment_content(title, doc, show_property=True, show_request_link=False):
         """Helper function to generate standardized comment content"""
+        doc_type = doc.doctype
+        doc_name = doc.name
+        customer = doc.customer
+        customer_name = doc.customer_name
+        amount = doc.grand_total if hasattr(doc, 'grand_total') else doc.base_grand_total
+        date_field = 'posting_date' if doc_type == 'Sales Invoice' else 'transaction_date'
+        date_value = doc.get_formatted(date_field)
+        
         content = f"""
         <div class='small'>
             <strong>{title}:</strong> 
-            <a href='/app/sales-invoice/{si.name}'>{si.name}</a>
+            <a href='/app/{doc_type.lower().replace(" ", "-")}/{doc_name}'>{doc_name}</a>
             <br>
             <strong>Customer:</strong> 
-            <a href='/app/customer/{si.customer}'>{si.customer_name}</a>
+            <a href='/app/customer/{customer}'>{customer_name}</a>
             <br>
-            <strong>Amount:</strong> {si.get_formatted("grand_total")}
+            <strong>Amount:</strong> {amount}
             <br>
-            <strong>Posting Date:</strong> {si.get_formatted("posting_date")}
+            <strong>{date_field.title()}:</strong> {date_value}
         """
         
         if show_request_link:
@@ -734,12 +765,12 @@ def add_transaction_comments(sales_invoice, usr_name, auto_repeat=None):
             </a>
             """
         
-        if si.get("auto_repeat"):
-            auto_repeat_name = frappe.db.get_value("Auto Repeat", si.auto_repeat, "name")
+        if doc.get("auto_repeat"):
+            auto_repeat_name = frappe.db.get_value("Auto Repeat", doc.auto_repeat, "name")
             content += f"""
             <br>
-            <strong>Recurring Invoice:</strong> 
-            <a href='/app/auto-repeat/{si.auto_repeat}'>{auto_repeat_name}</a>
+            <strong>Recurring {doc_type}:</strong> 
+            <a href='/app/auto-repeat/{doc.auto_repeat}'>{auto_repeat_name}</a>
             <br>
             <strong>Frequency:</strong> {auto_repeat.get("frequency") if auto_repeat else ""}
             """
@@ -748,93 +779,26 @@ def add_transaction_comments(sales_invoice, usr_name, auto_repeat=None):
         return content
 
     # Add comment to Utility Service Request
-    usr_comment = create_comment_content("Created Sales Invoice", sales_invoice)
+    usr_comment = create_comment_content(f"Created {transaction.doctype}", transaction)
     add_comment("Utility Service Request", usr_name, usr_comment)
 
     # Add comment to Utility Property if associated
     if auto_repeat and auto_repeat.get("utility_property"):
         property_comment = create_comment_content(
-            "Sales Invoice Created", 
-            sales_invoice, 
+            f"{transaction.doctype} Created", 
+            transaction, 
             show_property=False,
             show_request_link=True
         )
         add_comment("Utility Property", auto_repeat.get("utility_property"), property_comment)
 
-def add_comment(doctype, docname, content):
-    """Helper function to add a comment to a document"""
-    frappe.get_doc({
-        "doctype": "Comment",
-        "comment_type": "Info",
-        "reference_doctype": doctype,
-        "reference_name": docname,
-        "content": content
-    }).insert(ignore_permissions=True)
-    
-
-def create_base_sales_invoice(usr, items, customer, customer_name, posting_date, due_date, company):
-    """Create the base sales invoice document."""
-    si = frappe.new_doc("Sales Invoice")
-    si.update({
-        "customer": customer or usr.customer,
-        "customer_name": customer_name,
-        "ignore_default_payment_terms_template": usr.ignore_default_payment_terms_template,
-        "payment_terms_template": usr.payment_terms_template,
-        "tc_name": usr.tc_name,
-        "terms": usr.terms,
-        "company": company or usr.company or frappe.defaults.get_user_default("company"),
-        "posting_date": posting_date or nowdate(),
-        "due_date": due_date or add_days(nowdate(), 30),
-        "utility_service_request": usr.name,
-        "currency": usr.currency or frappe.defaults.get_user_default("currency"),
-        "price_list": usr.price_list,
-        "selling_price_list": usr.price_list,
-        "conversion_rate": 1.0,
-        "ignore_pricing_rule": 1,
-    })
-
-    for item in items:
-        item_code = item.get("item_code")
-        item_line = {
-            "item_code": item_code,
-            "item_name": item.get("item_name") or frappe.db.get_value("Item", item_code, "item_name"),
-            "description": item.get("description") or frappe.db.get_value("Item", item_code, "description"),
-            "uom": item.get("uom") or frappe.db.get_value("Item", item_code, "stock_uom"),
-            "qty": float(item.get("qty", 0)),
-            "rate": float(item.get("rate", 0)),
-            "warehouse": item.get("warehouse") or frappe.defaults.get_user_default("warehouse"),
-            "conversion_factor": 1.0,
-            "amount": float(item.get("amount", float(item.get("qty", 0)) * float(item.get("rate", 0))))
-        }
-
-        # Add any additional fields
-        for key, value in item.items():
-            if key not in item_line:
-                item_line[key] = value
-
-        si.append("items", item_line)
-
-    si.insert(ignore_permissions=True)
-
-    if frappe.db.get_single_value("Utility Billing Settings", "sales_invoice_creation_state") == "Submitted":
-        si.submit()
-
-    return si
-
-
-def create_single_auto_repeat_with_contract_details(si, usr, adjustment_rule, auto_repeat):
+def create_single_auto_repeat_with_contract_details(doc, usr, adjustment_rule, auto_repeat):
     """
-    Creates an Auto Repeat document for a Sales Invoice with comprehensive contract details,
-    including rent increment settings from the associated property.
-    
-    This function:
-    1. Retrieves increment settings from the property linked to the Utility Service Request
-    2. Calculates the appropriate end date for the first billing interval
-    3. Creates an Auto Repeat document with all contract metadata
-    4. Links the Auto Repeat to the Sales Invoice
+    Creates an Auto Repeat document for a transaction (Sales Order or Sales Invoice) with comprehensive contract details,
+    including increment settings from the associated property.
     
     Args:
-        si (Sales Invoice): The Sales Invoice document to be auto-repeated
+        doc (Document): The document to be auto-repeated (Sales Order or Sales Invoice)
         usr (Utility Service Request): The parent request containing property details
         auto_repeat (dict): Configuration for the auto-repeat including:
             - frequency: Daily/Weekly/Monthly/Yearly
@@ -846,11 +810,9 @@ def create_single_auto_repeat_with_contract_details(si, usr, adjustment_rule, au
     Returns:
         None: Creates the Auto Repeat document directly
     """
-    from frappe.utils import getdate, add_months, nowdate
+    from frappe.utils import getdate, add_months
     
     # Get the specific property configuration from Utility Service Request
-    # This looks for the property matching the one specified in auto_repeat settings
-    # Property doc contains critical billing parameters like increment intervals and percentages
     property_doc = next(
         (prop for prop in usr.requested_properties 
          if prop.utility_property == auto_repeat.get("utility_property")),
@@ -867,27 +829,23 @@ def create_single_auto_repeat_with_contract_details(si, usr, adjustment_rule, au
     contract_end_date = getdate(auto_repeat.get("end_date")) if auto_repeat.get("end_date") else None
     
     # Determine Auto Repeat end date:
-    # - With increments: End after first interval (but not beyond contract end)
-    # - Without increments: Use contract end date directly
     if has_increment:
-        # Calculate when the first billing interval should end
         interval_end_date = add_months(start_date, float(increment_interval))
         if adjustment_rule.effective_after_months and float(adjustment_rule.effective_after_months) > 0:
             interval_end_date = add_months(start_date, float(adjustment_rule.effective_after_months))
         
-        # Respect contract term limits if they exist
         if contract_end_date and interval_end_date > contract_end_date:
             end_date = contract_end_date
         else:
             end_date = interval_end_date
     else:
-        end_date = contract_end_date  # May be None for open-ended contracts
+        end_date = contract_end_date
     
-    # Create the Auto Repeat document with complete contract metadata
+    # Create the Auto Repeat document
     repeat_doc = frappe.get_doc({
         "doctype": "Auto Repeat",
-        "reference_doctype": "Sales Invoice",
-        "reference_document": si.name,  # Links to the specific invoice
+        "reference_doctype": doc.doctype,
+        "reference_document": doc.name,
         "frequency": auto_repeat.get("frequency"),
         "start_date": start_date,
         "end_date": end_date,
@@ -898,20 +856,20 @@ def create_single_auto_repeat_with_contract_details(si, usr, adjustment_rule, au
         "repeat_on_last_day": auto_repeat.get("repeat_on_last_day"),
         "auto_repeat_on_days": auto_repeat.get("repeat_on_days", []),
         
-        # Contract metadata for reference and future processing
+        # Contract metadata
         "contract_start_date": start_date,
         "contract_end_date": contract_end_date,
         "adjustment_rule": adjustment_rule.name,
         "enable_increment": 1 if has_increment else 0, 
     })
     
-    # Save the Auto Repeat and link it to the invoice
+    # Save the Auto Repeat and link it to the document
     repeat_doc.insert(ignore_permissions=True)
-    si.db_set("auto_repeat", repeat_doc.name)
+    doc.db_set("auto_repeat", repeat_doc.name)
     
     # User feedback with actionable link
     msg = (f"Created Auto Repeat <a href='/app/auto-repeat/{repeat_doc.name}'>{repeat_doc.name}</a> "
-           f"for {si.customer_name}'s invoice {si.name}")
+           f"for {doc.customer_name}'s {doc.doctype.lower()} {doc.name}")
     
     if has_increment:
         msg += (f"\n• First billing interval ends on {end_date} "
@@ -920,3 +878,13 @@ def create_single_auto_repeat_with_contract_details(si, usr, adjustment_rule, au
         msg += f"\n• Full contract term until {contract_end_date}"
     
     # frappe.msgprint(msg)
+
+def add_comment(doctype, docname, content):
+    """Helper function to add a comment to a document"""
+    frappe.get_doc({
+        "doctype": "Comment",
+        "comment_type": "Info",
+        "reference_doctype": doctype,
+        "reference_name": docname,
+        "content": content
+    }).insert(ignore_permissions=True)

--- a/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.py
+++ b/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.py
@@ -564,80 +564,131 @@ def create_sales_order_doc(docname, items, customer=None, customer_name=None, tr
 
     return so.name
 
- 
+
 @frappe.whitelist()
-def create_sales_invoice_doc(docname, items, customer=None, customer_name=None, posting_date=None, due_date=None, company=None, property=None):
+def create_sales_invoice_doc(
+    docname: str,
+    items: list | str,
+    customer: str = None,
+    customer_name: str = None,
+    posting_date: str = None,
+    due_date: str = None,
+    company: str = None,
+    property: str = None,
+    enable_auto_repeat: str = None,
+    adjustment_rule: str = None,
+    start_date: str = None,
+    end_date: str = None
+):
     """
-    Create a Sales Invoice from Utility Service Request and optionally create Auto Repeat document
+    Creates a Sales Invoice from a Utility Service Request and optionally creates an Auto Repeat document
     with rent increment details stored in the Auto Repeat document.
 
-    :param docname: Utility Service Request name
-    :param items: List of item dictionaries
-    :param customer: Customer ID
-    :param posting_date: Invoice date
-    :param due_date: Due date
-    :param company: Company
-    :param auto_repeat: Dict containing Auto Repeat settings
+    :param docname: Utility Service Request name (str)
+    :param items: List of item dictionaries (list or JSON string)
+                  Each item dictionary must contain 'item_code', 'qty', and 'rate'.
+    :param customer: Customer ID (str, optional)
+    :param customer_name: Customer Name (str, optional)
+    :param posting_date: Sales Invoice posting date (str, optional). If not provided,
+                         will attempt to use 'start_date' from utility property line.
+    :param due_date: Sales Invoice due date (str, optional).
+    :param company: Company (str, optional)
+    :param property: Utility Property name (str, optional)
+    :param enable_auto_repeat: Flag to enable auto repeat ('1' for true, others for false) (str, optional)
+    :param adjustment_rule: Name of the Billing Adjustment Rule to use (str, optional).
+                            If not provided, will attempt to use from utility property line.
+    :param start_date: Auto Repeat start date (str, optional). If not provided,
+                       will attempt to use 'start_date' from utility property line.
+    :param end_date: Auto Repeat end date (str, optional). If not provided,
+                     will attempt to use 'end_date' from utility property line.
+    :return: The name of the created Sales Invoice (str)
+    :raises frappe.ValidationError: If items are not valid or required fields are missing.
     """
-    # Parse inputs
-
     if isinstance(items, str):
         try:
             items = json.loads(items)
-        except Exception:
-            items = []
+        except json.JSONDecodeError:
+            frappe.throw("Items must be a valid JSON string or a list of item dictionaries.")
 
     if not isinstance(items, list):
         frappe.throw("Items must be a list of item dictionaries.")
 
-    # Validate items
     for item in items:
+        if not isinstance(item, dict):
+            frappe.throw("Each item in the 'items' list must be a dictionary.")
         if not item.get("item_code"):
-            frappe.throw("Item Code is required for all items")
-        if not item.get("qty"):
-            frappe.throw("Quantity is required for all items")
-        if item.get("rate") is None:
-            frappe.throw("Rate is required for all items")
+            frappe.throw("Item Code is required for all items.")
+        if item.get("qty") is None: 
+            frappe.throw("Quantity is required for all items.")
+        if item.get("rate") is None: 
+            frappe.throw("Rate is required for all items.")
 
     usr = frappe.get_doc("Utility Service Request", docname)
-    property_line = next(
-        (prop for prop in usr.requested_properties 
-         if prop.utility_property == property),
-        None
-    ) if property else None
 
-    # Create initial sales invoice
-    si = create_base_sales_invoice(usr, items, customer, customer_name, 
-                                 posting_date, due_date, company)
-    
-    # Handle auto repeat creation with contract details
-    if property_line and property_line.adjustment_rule:
-        adjustment_rule = frappe.get_doc("Billing Adjustment Rule", property_line.adjustment_rule)
-        create_single_auto_repeat_with_contract_details(
-            si, 
-            usr, 
-            adjustment_rule,
-            {
-                "frequency": adjustment_rule.frequency,
-                "start_date": property_line.start_date,
-                "end_date": property_line.end_date,
-                "utility_property": property_line.utility_property,
-                "submit_on_creation": adjustment_rule.submit_on_creation,
-                "repeat_on_day": adjustment_rule.repeat_on_day,
-                "repeat_on_last_day": adjustment_rule.repeat_on_last_day,
-                "repeat_on_days": adjustment_rule.repeat_on_days,
-            }
+    property_line = None
+    if property:
+        property_line = next(
+            (prop for prop in usr.requested_properties
+             if prop.utility_property == property),
+            None
         )
 
-        # Add comprehensive comments to relevant documents
-        add_transaction_comments(si, docname, {
-            "frequency": adjustment_rule.frequency,
-            "start_date": property_line.start_date,
-            "end_date": property_line.end_date,
-            "utility_property": property_line.utility_property,
-        } if property_line else None)
+    final_posting_date = posting_date or (property_line.start_date if property_line else None) or frappe.utils.nowdate()
+    final_start_date = start_date or (property_line.start_date if property_line else None) or frappe.utils.nowdate()
+    final_end_date = end_date or (property_line.end_date if property_line else None)
+
+    si = frappe.get_doc({
+        "doctype": "Sales Invoice",
+        "utility_service_request": docname,
+        "customer": customer or usr.customer,
+        "customer_name": customer_name or usr.customer_name, 
+        "posting_date": final_posting_date,
+        "due_date": due_date, 
+        "company": company or usr.company, 
+        "set_draft_from_utility_service_request": 1, 
+        "items": []
+    })
+
+    for item_data in items:
+        si.append("items", {
+            "item_code": item_data.get("item_code"),
+            "qty": item_data.get("qty"),
+            "rate": item_data.get("rate"),
+            "uom": item_data.get("uom"), 
+            "amount": item_data.get("amount") 
+        })
+    si.insert()
+
+    if enable_auto_repeat == "1":
+        actual_adjustment_rule_name = adjustment_rule or property_line.adjustment_rule
+
+        if actual_adjustment_rule_name:
+            adjustment_rule_doc = frappe.get_doc("Billing Adjustment Rule", actual_adjustment_rule_name)
+
+            auto_repeat_settings = {
+                "frequency": adjustment_rule_doc.frequency,
+                "start_date": final_start_date,
+                "end_date": final_end_date,
+                "utility_property": property,
+                "submit_on_creation": adjustment_rule_doc.submit_on_creation,
+                "repeat_on_day": adjustment_rule_doc.repeat_on_day,
+                "repeat_on_last_day": adjustment_rule_doc.repeat_on_last_day,
+                "repeat_on_days": adjustment_rule_doc.repeat_on_days,
+            }
+
+            create_single_auto_repeat_with_contract_details(
+                si,
+                usr,
+                adjustment_rule_doc,
+                auto_repeat_settings
+            )
+
+            add_transaction_comments(si, docname, auto_repeat_settings)
+        else:
+            frappe.msgprint("Auto Repeat not created: No adjustment rule specified for property.")
 
     return si.name
+
 
 def add_transaction_comments(sales_invoice, usr_name, auto_repeat=None):
     """


### PR DESCRIPTION
This pull request introduces a **new and flexible auto-repeat feature** for **Sales Orders**, expanding the previously limited support (which only existed for Sales Invoices). It also significantly refactors sales document creation from Service Requests, improving modularity, configurability, and maintainability.

---

### 📦 Core Features Introduced

#### 1. 🔁 **Flexible Auto-Repeat Functionality**

* Enables **recurring billing** setup for both **Sales Orders** and **Sales Invoices**.
* Adds **new form fields** to the shared Sales Document Modal:

  * Auto-Repeat Start Date
  * Auto-Repeat End Date
  * Adjustment/Interval Rule
  * Optional Property Link
* **Improved flexibility:** Auto-repeat can now be configured **with or without a linked property**, supporting broader use cases.
* Fields support:

  * Conditional display logic
  * Dynamic field values
  * Validation and mandatory logic based on context

#### 2. 🧠 **Backend Support and Validation Enhancements**

* Backend logic now supports auto-repeat setup for **both** document types.
* Validates start/end dates, adjustment rules, and linked property (if present).
* Handles item attribute resolution and data preparation more robustly.
* Better error handling and logging for invalid inputs and failure scenarios.

---

### 🛠️ Refactoring & UI Enhancements

#### Consolidated Shared Modal Function

* Introduced a **unified modal function** for creating both Sales Orders and Sales Invoices.
* Action buttons for service requests updated to call the shared modal logic.
* Removed duplicated dialog logic for improved maintainability.

#### Enhanced Dialog UI & Configuration

* Improved customer and item sections for dynamic population and validation.
* Reorganized fields and labels for clearer interaction and guidance.
* Simplified configuration and customization for future extensibility.

---

### 🧪 Quality & Robustness Improvements

* Type hinting and inline documentation updates for better code readability.
* Improved reusability of common logic for transactions and auto-repeat handling.
* Support for both simple and complex service scenarios (e.g., contracts, adjustments, flexible billing).

---

### ✅ Key Improvements

* Auto-repeat now available for **Sales Orders** (in addition to existing Sales Invoice support).
* **Property link now optional** – supports standalone auto-repeat without requiring linked assets.
* Consistent experience and logic between both document types.
* More maintainable, extensible, and future-proof foundation for recurring billing.

---

### 🔗 Related Commits

* [`[0d00dda](https://github.com/navariltd/utility-billing/commit/0d00dda19c3fa8ff27ae587c9fed73c0611bfc37)`](https://github.com/navariltd/utility-billing/commit/0d00dda19c3fa8ff27ae587c9fed73c0611bfc37):
  Refactored service request actions and dialogs to consolidate document creation logic.

* [`[08492a2](https://github.com/navariltd/utility-billing/commit/08492a244ff1bf01efe208448061749e5fe72d42)`](https://github.com/navariltd/utility-billing/commit/08492a244ff1bf01efe208448061749e5fe72d42):
  Added front-end support for flexible auto-repeat fields in the Sales Document modal.

* [`[53df263](https://github.com/navariltd/utility-billing/commit/53df263d2c0ff83c7c3e649cc0e6e15377625cda)`](https://github.com/navariltd/utility-billing/commit/53df263d2c0ff83c7c3e649cc0e6e15377625cda):
  Introduced backend handling and validation for auto-repeat setup in Sales Orders; aligned logic with Sales Invoices.

---

### 📌 Final Notes

> This feature was **previously limited to Sales Invoices only**, but now supports **Sales Orders** as well. It also lifts the restriction of needing a property, making it **much more adaptable** to diverse billing needs including ad-hoc service contracts and non-asset-based recurring sales.

