### PR TITLE
fix(setup): remove demo setup call from after_install

### DIFF
--- a/utility_billing/utility_billing/patches/after_install.py
+++ b/utility_billing/utility_billing/patches/after_install.py
@@ -1,6 +1,5 @@
 import frappe
 from .create_fields_from_json import create_fields_from_json
-from .demo.setup import run_demo_setup
 
 def create_fields(site: str) -> None:
     current_app = frappe.get_installed_apps()[-1]  
@@ -18,5 +17,3 @@ def create_fields(site: str) -> None:
     create_fields_from_json("./custom_fields/sales_order.json", "Sales Order")
     create_fields_from_json("./custom_fields/sales_order_item.json", "Sales Order Item")
     create_fields_from_json("./custom_fields/auto_repeat.json", "Auto Repeat")
-
-    run_demo_setup()


### PR DESCRIPTION
This pull request removes unused functionality from the `utility_billing/utility_billing/patches/after_install.py` file to streamline the codebase. Specifically, the `run_demo_setup` function and its import have been removed.

Codebase cleanup:

* [`utility_billing/utility_billing/patches/after_install.py`](diffhunk://#diff-7fa0ad485a706b1e562d7ab8ea269d6e2ed9dfc17535100128a7dc427fb7f719L3): Removed the import for `run_demo_setup` from `.demo.setup` and the call to `run_demo_setup` within the `create_fields` function, as it is no longer needed. [[1]](diffhunk://#diff-7fa0ad485a706b1e562d7ab8ea269d6e2ed9dfc17535100128a7dc427fb7f719L3) [[2]](diffhunk://#diff-7fa0ad485a706b1e562d7ab8ea269d6e2ed9dfc17535100128a7dc427fb7f719L21-L22)