### PR TITLE
fix(setup): remove demo setup call from after_install 

### DIFF
--- a/utility_billing/utility_billing/patches/after_install.py
+++ b/utility_billing/utility_billing/patches/after_install.py
@@ -1,6 +1,5 @@
 import frappe
 from .create_fields_from_json import create_fields_from_json
-from .demo.setup import run_demo_setup
 
 def create_fields(site: str) -> None:
     current_app = frappe.get_installed_apps()[-1]  
@@ -18,5 +17,3 @@ def create_fields(site: str) -> None:
     create_fields_from_json("./custom_fields/sales_order.json", "Sales Order")
     create_fields_from_json("./custom_fields/sales_order_item.json", "Sales Order Item")
     create_fields_from_json("./custom_fields/auto_repeat.json", "Auto Repeat")
-
-    run_demo_setup()


### PR DESCRIPTION
This pull request simplifies the `create_fields` function in `utility_billing/utility_billing/patches/after_install.py` by removing unused imports and eliminating a redundant function call.

Code cleanup:

* Removed the unused `run_demo_setup` import from `utility_billing/utility_billing/patches/after_install.py`.
* Deleted the call to `run_demo_setup()` within the `create_fields` function, as it was no longer necessary.