### PR TITLE
feat: enhance property handling, recurring billing, and sales document configuration

### DIFF
--- a/utility_billing/utility_billing/doctype/utility_property/utility_property.json
+++ b/utility_billing/utility_billing/doctype/utility_property/utility_property.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_import": 1,
  "allow_rename": 1,
  "autoname": "field:property_name",
  "creation": "2024-11-06 15:58:52.896790",
@@ -370,7 +371,7 @@
  "index_web_pages_for_search": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2025-07-16 17:22:30.743196",
+ "modified": "2025-08-11 19:11:54.195303",
  "modified_by": "Administrator",
  "module": "Utility Billing",
  "name": "Utility Property",

--- a/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.js
+++ b/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.js
@@ -805,6 +805,9 @@ async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false)
 	const properties = (frm.doc.requested_properties || [])
 		.map((p) => p.utility_property)
 		.filter(Boolean);
+
+	const defaultProperty = properties.length === 1 ? frm.doc.requested_properties[0] : null;
+
 	// Add fields for Property and Auto Repeat settings
 	fields.push(
 		{
@@ -846,20 +849,17 @@ async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false)
 
 				// Update items with property and frequency if a matching property line is found
 				if (property_line) {
+					if (property_line.adjustment_rule) {
+						dialog.set_value("adjustment_rule", property_line.adjustment_rule);
+					}
+					if (property_line.end_date) {
+						dialog.set_value("end_date", property_line.end_date);
+					}
 					items.forEach((row) => {
 						row.utility_property = selected_value;
 						row.frequency = property_line.frequency; // Set frequency from property line
 
 						// Set adjustment_rule if it exists in the property line
-						if (property_line.adjustment_rule) {
-							dialog.set_value("adjustment_rule", property_line.adjustment_rule);
-						} // Set start_date if it exists in the property line
-						// if (property_line.start_date) {
-						// 	dialog.set_value("start_date", property_line.start_date);
-						// } // Set end_date if it exists in the property line
-						if (property_line.end_date) {
-							dialog.set_value("end_date", property_line.end_date);
-						}
 					});
 				} else {
 					// Clear property and frequency from items if no matching property line
@@ -881,6 +881,7 @@ async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false)
 			fieldtype: "Link",
 			options: "Billing Adjustment Rule",
 			depends_on: "eval:doc.enable_auto_repeat==1",
+			default: defaultProperty?.adjustment_rule,
 			mandatory_depends_on: "eval:doc.enable_auto_repeat==1",
 			description: __("Rule defining how billing amounts will adjust over time"),
 		},
@@ -892,7 +893,7 @@ async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false)
 			fieldname: "enable_auto_repeat",
 			label: __("Enable Auto Repeat"),
 			fieldtype: "Check",
-			default: 0,
+			default: docType === "Sales Order" ? 0 : 1,
 			description: __("Enable recurring billing for this document"),
 			change: function () {
 				// When enable_auto_repeat changes, update the visibility and mandatory status of date fields
@@ -934,6 +935,7 @@ async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false)
 			label: __("Recurring Billing End Date"),
 			fieldtype: "Date",
 			depends_on: "eval:doc.enable_auto_repeat==1", // Only show if auto-repeat is enabled
+			default: defaultProperty?.end_date,
 			mandatory_depends_on: "eval:doc.enable_auto_repeat==1", // Mandatory if auto-repeat is enabled
 			description: __("Date when recurring billing will stop"),
 		},

--- a/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.js
+++ b/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.js
@@ -649,7 +649,9 @@ function prepare_items_data(frm) {
 	const child_table = frm.fields_dict["items"];
 	const child_fields = child_table.grid.docfields;
 	const allowedFields = child_fields.map((f) => f.fieldname);
-
+	const properties = (frm.doc.requested_properties || [])
+		.map((p) => p.utility_property)
+		.filter(Boolean);
 	return frm.doc.items.map((item) => {
 		const qty = item.qty || 1;
 		const rate = item.rate || 0;
@@ -662,6 +664,7 @@ function prepare_items_data(frm) {
 			amount: flt(rate * qty),
 			qty: qty,
 			warehouse: item.warehouse || frappe.defaults.get_user_default("Warehouse"),
+			utility_property: properties.length == 1 ? properties[0] : null,
 			...item, // Include all other fields from the original item
 		};
 
@@ -894,7 +897,6 @@ async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false)
 			change: function () {
 				// When enable_auto_repeat changes, update the visibility and mandatory status of date fields
 				const isChecked = this.get_value();
-				dialog.toggle_display(["start_date", "end_date", "adjustment_rule"], isChecked);
 				dialog.set_df_property("start_date", "reqd", isChecked);
 				dialog.set_df_property("end_date", "reqd", isChecked);
 				dialog.set_df_property("adjustment_rule", "reqd", isChecked);
@@ -1034,12 +1036,6 @@ async function showSalesDocumentModal(frm, docType, allowAdditionalRows = false)
 
 	// Configure the dialog after initialization (e.g., initial field visibility)
 	configure_dialog(dialog, frm);
-
-	// Manually trigger initial visibility for auto-repeat fields based on default value
-	dialog.toggle_display(
-		["start_date", "end_date", "adjustment_rule"],
-		dialog.get_value("enable_auto_repeat")
-	);
 }
 
 // Update the action buttons to use the new common modal function

--- a/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.py
+++ b/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.py
@@ -517,6 +517,7 @@ def create_sales_order_doc(
     so = frappe.get_doc({
         "doctype": "Sales Order",
         "utility_service_request": docname,
+        "utility_property": property if property else None,
         "customer": customer or usr.customer,
         "customer_name": customer_name or usr.customer_name,
         "transaction_date": final_transaction_date,
@@ -583,6 +584,7 @@ def create_sales_invoice_doc(
     si = frappe.get_doc({
         "doctype": "Sales Invoice",
         "utility_service_request": docname,
+        "utility_property": property if property else None,
         "customer": customer or usr.customer,
         "customer_name": customer_name or usr.customer_name,
         "posting_date": final_posting_date,
@@ -642,35 +644,6 @@ def _get_common_doc_details(docname, property, transaction_date, start_date, end
     final_end_date = end_date or (property_line.end_date if property_line else None)
 
     return usr, property_line, primary_date, final_start_date, final_end_date
-
-def _handle_auto_repeat(doc, usr, property, enable_auto_repeat, adjustment_rule, start_date, end_date):
-    if enable_auto_repeat == "1":
-        actual_adjustment_rule_name = adjustment_rule or (property.adjustment_rule if property else None)
-
-        if actual_adjustment_rule_name:
-            adjustment_rule_doc = frappe.get_doc("Billing Adjustment Rule", actual_adjustment_rule_name)
-
-            auto_repeat_settings = {
-                "frequency": adjustment_rule_doc.frequency,
-                "start_date": start_date,
-                "end_date": end_date,
-                "utility_property": property.utility_property if property else None, # Pass the utility_property name
-                "submit_on_creation": adjustment_rule_doc.submit_on_creation,
-                "repeat_on_day": adjustment_rule_doc.repeat_on_day,
-                "repeat_on_last_day": adjustment_rule_doc.repeat_on_last_day,
-                "repeat_on_days": adjustment_rule_doc.repeat_on_days,
-            }
-
-            create_single_auto_repeat_with_contract_details(
-                doc,
-                usr,
-                adjustment_rule_doc,
-                auto_repeat_settings
-            )
-
-            add_transaction_comments(doc, usr.name, auto_repeat_settings)
-        else:
-            frappe.msgprint("Auto Repeat not created: No adjustment rule specified for property.")
 
 
 def add_transaction_comments(transaction, usr_name, auto_repeat=None):

--- a/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.py
+++ b/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.py
@@ -522,6 +522,9 @@ def create_sales_order_doc(
         "transaction_date": final_transaction_date,
         "delivery_date": add_days(final_transaction_date, 7),
         "company": company or usr.company,
+        "payment_terms_template": usr.payment_terms_template if hasattr(usr, "payment_terms_template") else None,
+        "tc_name": usr.tc_name if hasattr(usr, "tc_name") else None,
+        "terms": usr.terms if hasattr(usr, "terms") else None,
         "items": []
     })
 
@@ -586,6 +589,10 @@ def create_sales_invoice_doc(
         "due_date": due_date,
         "company": company or usr.company,
         "set_draft_from_utility_service_request": 1,
+        "ignore_default_payment_terms_template": 1 if usr.payment_terms_template else 0,
+        "payment_terms_template": usr.payment_terms_template if hasattr(usr, "payment_terms_template") else None,
+        "tc_name": usr.tc_name if hasattr(usr, "tc_name") else None,
+        "terms": usr.terms if hasattr(usr, "terms") else None,
         "items": []
     })
 


### PR DESCRIPTION
This pull request introduces several improvements and enhancements to the utility billing module, focusing on better handling of property-related data in service requests, sales documents, and recurring billing logic. The changes streamline the assignment of utility properties, improve the defaulting and configuration of auto-repeat (recurring billing) settings, and add more robust support for payment terms and contractual details in sales documents.

**Enhancements to property handling and recurring billing:**

* Improved assignment of `utility_property` in items and sales document creation, ensuring that when a single property is selected, it is consistently used throughout the process. [[1]](diffhunk://#diff-a2a122f96a483b25929b8c442f698f2b13ba0d2fe075bacb9bdc726603ce89cfL652-R654) [[2]](diffhunk://#diff-a2a122f96a483b25929b8c442f698f2b13ba0d2fe075bacb9bdc726603ce89cfR667) [[3]](diffhunk://#diff-1165725ad539174596b3caf261f66edb81b6686e4188db87f4c262419cb13f5eR520-R528) [[4]](diffhunk://#diff-1165725ad539174596b3caf261f66edb81b6686e4188db87f4c262419cb13f5eR587-R597)
* Enhanced the recurring billing (auto-repeat) modal to better default and propagate property-related fields such as `adjustment_rule` and `end_date` based on the selected property, and adjusted the default value of the auto-repeat toggle depending on the document type. [[1]](diffhunk://#diff-a2a122f96a483b25929b8c442f698f2b13ba0d2fe075bacb9bdc726603ce89cfR808-R810) [[2]](diffhunk://#diff-a2a122f96a483b25929b8c442f698f2b13ba0d2fe075bacb9bdc726603ce89cfL846-R862) [[3]](diffhunk://#diff-a2a122f96a483b25929b8c442f698f2b13ba0d2fe075bacb9bdc726603ce89cfR884) [[4]](diffhunk://#diff-a2a122f96a483b25929b8c442f698f2b13ba0d2fe075bacb9bdc726603ce89cfL892-L897) [[5]](diffhunk://#diff-a2a122f96a483b25929b8c442f698f2b13ba0d2fe075bacb9bdc726603ce89cfR938)
* Removed the now-unnecessary `_handle_auto_repeat` function, likely due to refactoring and improved handling of auto-repeat logic elsewhere.

**Support for payment terms and contract details:**

* Added support for including `payment_terms_template`, `tc_name`, and `terms` fields in both Sales Order and Sales Invoice documents, and added logic to ignore default payment terms if a specific template is set. [[1]](diffhunk://#diff-1165725ad539174596b3caf261f66edb81b6686e4188db87f4c262419cb13f5eR520-R528) [[2]](diffhunk://#diff-1165725ad539174596b3caf261f66edb81b6686e4188db87f4c262419cb13f5eR587-R597)

**Configuration and import improvements:**

* Enabled import functionality for the `Utility Property` doctype, making it easier to bulk upload or update property records.

These changes collectively improve the user experience and data integrity when managing utility properties, service requests, and recurring billing scenarios.