### PR TITLE
feat(auto-repeat): add manual trigger from form and list view

### DIFF
--- a/utility_billing/hooks.py
+++ b/utility_billing/hooks.py
@@ -61,11 +61,15 @@ app_include_js = "/assets/utility_billing/js/demo.js"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
-doctype_js = {"Item Price": "utility_billing/overrides/client/item_price.js"}
-doctype_js = {"Contract": "utility_billing/overrides/client/contract.js"}
+doctype_js = {
+    "Item Price": "utility_billing/overrides/client/item_price.js",
+    "Contract": "utility_billing/overrides/client/contract.js",
+    "Auto Repeat": "utility_billing/overrides/client/auto_repeat.js"
+}
 # doctype_js = {"Customer": "utility_billing/overrides/client/customer.js"}
 doctype_list_js = {
-    "Sales Order": "utility_billing/overrides/client/sales_order_list.js"
+    "Sales Order": "utility_billing/overrides/client/sales_order_list.js",
+    "Auto Repeat": "utility_billing/overrides/client/auto_repeat_list.js"
 }
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}

--- a/utility_billing/utility_billing/overrides/client/auto_repeat.js
+++ b/utility_billing/utility_billing/overrides/client/auto_repeat.js
@@ -1,0 +1,26 @@
+// Copyright (c) 2025, Navari and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Auto Repeat", {
+	refresh: function (frm) {
+		if (!frm.doc.next_schedule_date || frm.doc.disabled) return;
+
+		let today = frappe.datetime.get_today();
+		if (frm.doc.next_schedule_date <= today) {
+			frm.add_custom_button(__("Create Now"), function () {
+				frappe.call({
+					method: "utility_billing.utility_billing.overrides.server.auto_repeat.create_repeated_entries",
+					args: {
+						data: [{ name: frm.doc.name }],
+					},
+					callback: function (r) {
+						if (!r.exc) {
+							frappe.msgprint(__("Documents created successfully"));
+							frm.reload_doc();
+						}
+					},
+				});
+			});
+		}
+	},
+});

--- a/utility_billing/utility_billing/overrides/client/auto_repeat_list.js
+++ b/utility_billing/utility_billing/overrides/client/auto_repeat_list.js
@@ -1,0 +1,41 @@
+// Copyright (c) 2025, Navari and contributors
+// For license information, please see license.txt
+
+frappe.listview_settings["Auto Repeat"] = {
+	onload: function (listview) {
+		listview.page.add_action_item(__("Run Selected Auto Repeats"), function () {
+			const selected = listview.get_checked_items().map((item) => item.name);
+			if (!selected.length) {
+				frappe.msgprint(__("Please select at least one Auto Repeat"));
+				return;
+			}
+
+			frappe.call({
+				method: "utility_billing.utility_billing.overrides.server.auto_repeat.create_repeated_entries",
+				args: {
+					data: selected.map((name) => ({ name })),
+				},
+				callback: function (r) {
+					if (!r.exc) {
+						frappe.msgprint(__("Selected Auto Repeats processed successfully"));
+						listview.refresh();
+					}
+				},
+			});
+		});
+
+		listview.page.add_inner_button(__("Run All Due Auto Repeats"), function () {
+			frappe.confirm(__("Are you sure you want to run all due Auto Repeats?"), function () {
+				frappe.call({
+					method: "utility_billing.utility_billing.overrides.server.auto_repeat.run_all_due_auto_repeats",
+					callback: function (r) {
+						if (!r.exc) {
+							frappe.msgprint(__("All due Auto Repeats processed successfully"));
+							listview.refresh();
+						}
+					},
+				});
+			});
+		});
+	},
+};

--- a/utility_billing/utility_billing/overrides/server/auto_repeat.py
+++ b/utility_billing/utility_billing/overrides/server/auto_repeat.py
@@ -272,3 +272,51 @@ def add_audit_comment(
             "reference_name": name,
             "content": comment_msg
         }).insert(ignore_permissions=True)
+
+
+@frappe.whitelist()
+def create_repeated_entries(data):
+    """Create Auto Repeat documents for given list of names"""
+    import json
+
+    if isinstance(data, str):
+        data = json.loads(data)
+
+    for d in data:
+        try:
+            doc = frappe.get_doc("Auto Repeat", d["name"])
+
+            schedule_date = doc.get_next_schedule_date(schedule_date=doc.next_schedule_date)
+            next_schedule_date = getdate(doc.next_schedule_date)
+            current_date = getdate(today())
+            
+            if next_schedule_date <= current_date and not doc.disabled:
+                doc.create_documents()
+                if schedule_date and not doc.disabled:
+                    frappe.db.set_value("Auto Repeat", doc.name, "next_schedule_date", schedule_date)
+
+            if doc.is_completed():
+                doc.status = "Completed"
+                doc.save()
+
+        except Exception as e:
+            frappe.log_error(frappe.get_traceback(), f"Auto Repeat Creation Failed for {d['name']}")
+            frappe.throw(f"Failed to process {d['name']}: {e}")
+
+@frappe.whitelist()
+def run_all_due_auto_repeats():
+    """Run all Auto Repeats with next_schedule_date <= today."""
+    today_date = getdate(today())
+    names = frappe.get_all(
+        "Auto Repeat",
+        filters={"disabled": 0, "next_schedule_date": ["<=", today_date]},
+        pluck="name"
+    )
+
+    if not names:
+        return "No due Auto Repeats found"
+
+    data = [{"name": name} for name in names]
+    create_repeated_entries(data)
+
+    return f"Processed {len(names)} Auto Repeats"


### PR DESCRIPTION
This pull request adds new functionality for handling Auto Repeat documents in the Utility Billing module, allowing users to manually trigger document creation both from the form and the list view. It introduces new client-side scripts and server-side methods to support these actions, and updates the module hooks to register these scripts.

**Auto Repeat Functionality Enhancements**

* Added client-side script `auto_repeat.js` for the `Auto Repeat` doctype, enabling a "Create Now" button on the form when the next schedule date is due and the document is active. This button triggers immediate document creation via a server call.
* Added client-side script `auto_repeat_list.js` for the `Auto Repeat` list view, allowing users to run selected or all due Auto Repeats directly from the list interface. Includes confirmation dialogs and feedback messages.

**Server-side Support for Auto Repeat Actions**

* Implemented `create_repeated_entries` method to process a list of Auto Repeat names, creating documents if due and updating their schedule/status accordingly. Handles errors gracefully and logs failures.
* Added `run_all_due_auto_repeats` method to find and process all Auto Repeats that are due (not disabled and schedule date <= today), leveraging the above method for batch processing.

**Module Hook Updates**

* Updated `hooks.py` to register the new client-side scripts for the `Auto Repeat` doctype and its list view, ensuring the new UI functionality is available.