### PR TITLE
feat(utility): enhance service request flexibility and billing reports

### DIFF
--- a/utility_billing/fixtures/item_group.json
+++ b/utility_billing/fixtures/item_group.json
@@ -70,29 +70,5 @@
     "website_specifications": [],
     "website_title": null,
     "weightage": 0
-  },
-  {
-    "description": null,
-    "docstatus": 0,
-    "doctype": "Item Group",
-    "filter_attributes": [],
-    "filter_fields": [],
-    "image": null,
-    "include_descendants": 0,
-    "is_group": 0,
-    "is_utility_item_group": 1,
-    "item_group_defaults": [],
-    "item_group_name": "Other Utilities",
-    "modified": "2025-08-12 11:19:37.367327",
-    "name": "Other Utilities",
-    "old_parent": "Utility and Rental",
-    "parent_item_group": "Utility and Rental",
-    "route": "other-utilities",
-    "show_in_website": 0,
-    "slideshow": null,
-    "taxes": [],
-    "website_specifications": [],
-    "website_title": null,
-    "weightage": 0
   }
 ]

--- a/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.json
+++ b/utility_billing/utility_billing/doctype/utility_service_request/utility_service_request.json
@@ -244,6 +244,7 @@
   },
   {
    "allow_bulk_edit": 1,
+   "allow_on_submit": 1,
    "fieldname": "items",
    "fieldtype": "Table",
    "label": "Items",
@@ -354,6 +355,7 @@
    "options": "Payment Terms Template"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "utility_bill_structure",
    "fieldtype": "Link",
    "label": "Utility Bill Structure",
@@ -489,7 +491,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-14 14:21:59.339486",
+ "modified": "2025-09-09 15:33:49.336992",
  "modified_by": "Administrator",
  "module": "Utility Billing",
  "name": "Utility Service Request",

--- a/utility_billing/utility_billing/report/property_billing_overview/property_billing_overview.py
+++ b/utility_billing/utility_billing/report/property_billing_overview/property_billing_overview.py
@@ -48,6 +48,7 @@ class PropertyBillingOverview:
         self.get_monthly_rates()
         self.get_billing_data()
         self.process_data()
+        self.clean_columns()
         
         return self.columns, self.data
 
@@ -146,7 +147,11 @@ class PropertyBillingOverview:
             .where(ubsi.parent.isin(bill_structure_names))
             .run(as_dict=True))
             
-        self.monthly_rates = {(item.utility_bill_structure, item.item): item.monthly_rate for item in rate_items}
+        rate_totals = defaultdict(float)
+        for item in rate_items:
+            rate_totals[(item.utility_bill_structure, item.item)] += flt(item.monthly_rate, self.currency_precision)
+        self.monthly_rates = dict(rate_totals)
+
 
     def get_billing_data(self):
         property_list = [c.property for c in self.contracts]
@@ -218,7 +223,6 @@ class PropertyBillingOverview:
             if not bill_type:
                 continue
                 
-        # First calculate customer totals
             item_amount = flt(invoice.base_amount, self.currency_precision)
             
             self.update_billing_data(property_key, bill_type, item_amount)
@@ -244,7 +248,6 @@ class PropertyBillingOverview:
                 soi.item_code,
                 soi.base_amount,
                 soi.delivered_qty,
-        # First calculate customer totals
                 soi.qty
             )
             .where(so.docstatus == 1)
@@ -259,7 +262,6 @@ class PropertyBillingOverview:
         for order in orders:
             if order.name in invoiced_qty and invoiced_qty[order.name] >= order.qty:
                 continue
-        # First calculate customer totals
                 
             property_key = (order.utility_property, order.customer)
             bill_type = self.get_bill_type_for_item(order.utility_service_request, order.item_code)
@@ -459,7 +461,7 @@ class PropertyBillingOverview:
                     rate_value = self.monthly_rates.get(rate_key, 0)
             
             row.update({
-                f"{bill_type_name}_rate": rate_value if is_first_row_for_customer else "",
+                f"{bill_type_name}_rate": billing_info["bill_type_rate"].get(bt.name, rate_value),
                 f"{bill_type_name}_invoiced": billing_info["bill_type_invoiced"].get(bt.name, 0),
                 f"{bill_type_name}_ordered": billing_info["bill_type_ordered"].get(bt.name, 0)
             })
@@ -518,3 +520,25 @@ class PropertyBillingOverview:
         ])
         
         self.columns = base_columns
+        
+    def clean_columns(self):
+        cols_to_remove = set()
+
+        for col in self.columns:
+            fieldname = col.get("fieldname")
+            if not fieldname or not any(suffix in fieldname for suffix in ["_rate", "_ordered", "_invoiced"]):
+                continue
+
+            all_zero = all(
+                not row.get(fieldname) or flt(row.get(fieldname)) == 0
+                for row in self.data
+            )
+
+            if all_zero:
+                cols_to_remove.add(fieldname)
+
+        self.columns = [col for col in self.columns if col.get("fieldname") not in cols_to_remove]
+
+        for row in self.data:
+            for fieldname in cols_to_remove:
+                row.pop(fieldname, None)


### PR DESCRIPTION
This pull request introduces several improvements to the `property_billing_overview` report logic and some configuration updates for utility billing fixtures and doctypes. The main changes focus on cleaning up report columns, improving monthly rate calculations, and allowing certain fields to be edited after submission.

**Report logic improvements:**

* Added a new `clean_columns` method to `property_billing_overview.py` that removes columns (and their corresponding row values) for rates, orders, and invoices if all their values are zero, resulting in cleaner report output. (`utility_billing/utility_billing/report/property_billing_overview/property_billing_overview.py`) [[1]](diffhunk://#diff-15ffc764e8b5b5de775179a24721b3736894e9e2599d702d986f1ee23af4df13R523-R544) [[2]](diffhunk://#diff-15ffc764e8b5b5de775179a24721b3736894e9e2599d702d986f1ee23af4df13R51)
* Improved monthly rate calculation by summing rates for duplicate `(utility_bill_structure, item)` keys using `defaultdict`, ensuring accurate aggregation. (`property_billing_overview.py`)
* Updated logic in `add_bill_type_data` to use per-customer bill type rates when available, rather than only the default rate value. (`property_billing_overview.py`)
* Removed redundant comments in invoice and sales order processing for clarity. (`property_billing_overview.py`) [[1]](diffhunk://#diff-15ffc764e8b5b5de775179a24721b3736894e9e2599d702d986f1ee23af4df13L221) [[2]](diffhunk://#diff-15ffc764e8b5b5de775179a24721b3736894e9e2599d702d986f1ee23af4df13L247) [[3]](diffhunk://#diff-15ffc764e8b5b5de775179a24721b3736894e9e2599d702d986f1ee23af4df13L262)

**Configuration updates:**

* Enabled `allow_on_submit` for the `items` table and `utility_bill_structure` link fields in the `Utility Service Request` doctype, allowing edits after submission. (`utility_service_request.json`) [[1]](diffhunk://#diff-44c241f800813519cbccb79293bd3f84042d357677ef200b4c46066edd229863R247) [[2]](diffhunk://#diff-44c241f800813519cbccb79293bd3f84042d357677ef200b4c46066edd229863R358)
* Removed the `Other Utilities` entry from the `item_group.json` fixture, possibly to streamline available utility item groups. (`item_group.json`)