### PR TITLE
fix(property_billing_overview): distribute payments using invoice/order grand total

### DIFF
--- a/utility_billing/utility_billing/report/property_billing_overview/property_billing_overview.py
+++ b/utility_billing/utility_billing/report/property_billing_overview/property_billing_overview.py
@@ -8,8 +8,10 @@ from erpnext.accounts.utils import get_currency_precision, get_balance_on
 from collections import defaultdict
 from frappe.query_builder import functions as fn
 
+
 def execute(filters=None):
     return PropertyBillingOverview(filters).run()
+
 
 class PropertyBillingOverview:
     def __init__(self, filters=None):
@@ -29,35 +31,37 @@ class PropertyBillingOverview:
             frappe.throw(_("Company is required"))
         if not self.filters.get("from_date") or not self.filters.get("to_date"):
             frappe.throw(_("Date range is required"))
-                    
+
         self.filters.from_date = getdate(self.filters.from_date)
         self.filters.to_date = getdate(self.filters.to_date)
-                
+
         if self.filters.from_date > self.filters.to_date:
             frappe.throw(_("From Date cannot be after To Date"))
 
     def run(self):
         self.get_bill_types()
         self.get_columns()
-        
+
         self.get_contract_data()
-                
+
         if not self.contracts:
             return self.columns, self.data
-                    
+
         self.build_bill_item_mapping()
         self.get_monthly_rates()
         self.get_billing_data()
         self.process_data()
         self.clean_columns()
-                
+
         return self.columns, self.data
 
     def get_bill_types(self):
-        self.bill_types = frappe.get_all("Item Group",
+        self.bill_types = frappe.get_all(
+            "Item Group",
             filters={"is_utility_item_group": 1},
             fields=["name"],
-            order_by="name")
+            order_by="name",
+        )
 
     def get_contract_data(self):
         contract = frappe.qb.DocType("Contract")
@@ -69,11 +73,16 @@ class PropertyBillingOverview:
 
         query = (
             frappe.qb.from_(contract)
-            .join(contract_property).on(contract_property.parent == contract.name)
-            .join(property_doc).on(property_doc.name == contract_property.utility_property)
-            .left_join(service_request).on(service_request.name == contract.utility_service_request)
-            .left_join(customer).on(customer.name == contract.party_name)
-            .left_join(adjustment_rule).on(adjustment_rule.name == contract_property.adjustment_rule)
+            .join(contract_property)
+            .on(contract_property.parent == contract.name)
+            .join(property_doc)
+            .on(property_doc.name == contract_property.utility_property)
+            .left_join(service_request)
+            .on(service_request.name == contract.utility_service_request)
+            .left_join(customer)
+            .on(customer.name == contract.party_name)
+            .left_join(adjustment_rule)
+            .on(adjustment_rule.name == contract_property.adjustment_rule)
             .select(
                 contract.name.as_("contract"),
                 contract.party_name.as_("customer"),
@@ -94,82 +103,105 @@ class PropertyBillingOverview:
                 contract_property.start_date,
                 contract_property.end_date,
                 contract_property.adjustment_rule,
-                adjustment_rule.frequency.as_("billing_frequency")
+                adjustment_rule.frequency.as_("billing_frequency"),
             )
             .where(contract.docstatus == 1)
             .where(service_request.company == self.filters.company)
         )
 
         if self.filters.get("property"):
-            query = query.where(contract_property.utility_property == self.filters.property)
+            query = query.where(
+                contract_property.utility_property == self.filters.property
+            )
         if self.filters.get("customer"):
             query = query.where(contract.party_name == self.filters.customer)
 
-        self.contracts = query.orderby(contract.party_name, property_doc.property_name, property_doc.unit_number).run(as_dict=True)
-                
+        self.contracts = query.orderby(
+            contract.party_name, property_doc.property_name, property_doc.unit_number
+        ).run(as_dict=True)
+
         for contract in self.contracts:
             self.property_contract_map[contract.property] = contract
 
     def build_bill_item_mapping(self):
-        bill_structure_names = list(set(c.utility_bill_structure for c in self.contracts if c.utility_bill_structure))
+        bill_structure_names = list(
+            set(
+                c.utility_bill_structure
+                for c in self.contracts
+                if c.utility_bill_structure
+            )
+        )
         if not bill_structure_names:
             return
-                    
+
         ubsi = frappe.qb.DocType("Utility Bill Structure Item")
         item = frappe.qb.DocType("Item")
-                
+
         bill_structure_items = (
             frappe.qb.from_(ubsi)
-            .join(item).on(item.name == ubsi.item)
+            .join(item)
+            .on(item.name == ubsi.item)
             .select(
-                ubsi.item,
-                item.item_group,
-                ubsi.parent.as_("utility_bill_structure")
+                ubsi.item, item.item_group, ubsi.parent.as_("utility_bill_structure")
             )
             .where(ubsi.parent.isin(bill_structure_names))
-            .run(as_dict=True))
-                    
+            .run(as_dict=True)
+        )
+
         for item in bill_structure_items:
-            self.bill_item_mapping.setdefault(item.utility_bill_structure, {})[item.item] = item.item_group
+            self.bill_item_mapping.setdefault(item.utility_bill_structure, {})[
+                item.item
+            ] = item.item_group
 
     def get_monthly_rates(self):
-        bill_structure_names = list(set(c.utility_bill_structure for c in self.contracts if c.utility_bill_structure))
+        bill_structure_names = list(
+            set(
+                c.utility_bill_structure
+                for c in self.contracts
+                if c.utility_bill_structure
+            )
+        )
         if not bill_structure_names:
             return
-                    
+
         ubsi = frappe.qb.DocType("Utility Bill Structure Item")
         rate_items = (
             frappe.qb.from_(ubsi)
             .select(
                 ubsi.item,
                 ubsi.total.as_("monthly_rate"),
-                ubsi.parent.as_("utility_bill_structure")
+                ubsi.parent.as_("utility_bill_structure"),
             )
             .where(ubsi.parent.isin(bill_structure_names))
-            .run(as_dict=True))
-                    
+            .run(as_dict=True)
+        )
+
         rate_totals = defaultdict(float)
         for item in rate_items:
-            rate_totals[(item.utility_bill_structure, item.item)] += flt(item.monthly_rate, self.currency_precision)
+            rate_totals[(item.utility_bill_structure, item.item)] += flt(
+                item.monthly_rate, self.currency_precision
+            )
         self.monthly_rates = dict(rate_totals)
 
     def get_billing_data(self):
         property_list = [c.property for c in self.contracts]
         customer_list = [c.customer for c in self.contracts if c.customer]
 
-        self.billing_data = defaultdict(lambda: {
-            "invoiced": 0,
-            "paid": 0,
-            "outstanding": 0,
-            "ordered": 0,
-            "opening_outstanding": 0,
-            "current_outstanding": 0,
-            "bill_type_invoiced": defaultdict(float),
-            "bill_type_paid": defaultdict(float),
-            "bill_type_outstanding": defaultdict(float),
-            "bill_type_ordered": defaultdict(float),
-            "bill_type_rate": defaultdict(float)
-        })
+        self.billing_data = defaultdict(
+            lambda: {
+                "invoiced": 0,
+                "paid": 0,
+                "outstanding": 0,
+                "ordered": 0,
+                "opening_outstanding": 0,
+                "current_outstanding": 0,
+                "bill_type_invoiced": defaultdict(float),
+                "bill_type_paid": defaultdict(float),
+                "bill_type_outstanding": defaultdict(float),
+                "bill_type_ordered": defaultdict(float),
+                "bill_type_rate": defaultdict(float),
+            }
+        )
 
         if not property_list or not customer_list:
             return
@@ -186,19 +218,22 @@ class PropertyBillingOverview:
                 party_type="Customer",
                 party=customer,
                 date=self.filters.from_date,
-                company=self.filters.company
+                company=self.filters.company,
             )
-                        
+
             for contract in (c for c in self.contracts if c.customer == customer):
-                self.billing_data[(contract.property, contract.customer)]["opening_outstanding"] = opening_balance
+                self.billing_data[(contract.property, contract.customer)][
+                    "opening_outstanding"
+                ] = opening_balance
 
     def get_invoices(self, property_list, customer_list):
         si = frappe.qb.DocType("Sales Invoice")
         sii = frappe.qb.DocType("Sales Invoice Item")
-                
+
         invoices = (
             frappe.qb.from_(si)
-            .join(sii).on(sii.parent == si.name)
+            .join(sii)
+            .on(sii.parent == si.name)
             .select(
                 si.name.as_("invoice"),
                 si.customer,
@@ -214,17 +249,22 @@ class PropertyBillingOverview:
             .where(si.docstatus == 1)
             .where(si.customer.isin(customer_list))
             .where(sii.utility_property.isin(property_list))
-            .where(si.posting_date.between(self.filters.from_date, self.filters.to_date))
-            .run(as_dict=True))
-                    
+            .where(
+                si.posting_date.between(self.filters.from_date, self.filters.to_date)
+            )
+            .run(as_dict=True)
+        )
+
         for invoice in invoices:
             property_key = (invoice.utility_property, invoice.customer)
-            bill_type = self.get_bill_type_for_item(invoice.utility_service_request, invoice.item_code)
+            bill_type = self.get_bill_type_for_item(
+                invoice.utility_service_request, invoice.item_code
+            )
             if not bill_type:
                 continue
-                            
+
             item_amount = flt(invoice.base_amount, self.currency_precision)
-                        
+
             self.update_billing_data(property_key, bill_type, item_amount)
 
     def update_billing_data(self, property_key, bill_type, invoiced):
@@ -235,10 +275,11 @@ class PropertyBillingOverview:
     def get_sales_orders(self, property_list, customer_list):
         so = frappe.qb.DocType("Sales Order")
         soi = frappe.qb.DocType("Sales Order Item")
-                
+
         orders = (
             frappe.qb.from_(soi)
-            .join(so).on(soi.parent == so.name)
+            .join(so)
+            .on(soi.parent == so.name)
             .select(
                 so.name.as_("order"),
                 so.customer,
@@ -248,38 +289,44 @@ class PropertyBillingOverview:
                 soi.item_code,
                 soi.base_amount,
                 soi.delivered_qty,
-                soi.qty
+                soi.qty,
             )
             .where(so.docstatus == 1)
             .where(so.customer.isin(customer_list))
             .where(soi.utility_property.isin(property_list))
-            .where(so.transaction_date.between(self.filters.from_date, self.filters.to_date))
-            .where(so.status.notin(['Cancelled', 'Closed']))
-            .run(as_dict=True))
-                    
+            .where(
+                so.transaction_date.between(
+                    self.filters.from_date, self.filters.to_date
+                )
+            )
+            .where(so.status.notin(["Cancelled", "Closed"]))
+            .run(as_dict=True)
+        )
+
         invoiced_qty = self.get_invoiced_qty_for_orders()
-                    
+
         for order in orders:
             if order.name in invoiced_qty and invoiced_qty[order.name] >= order.qty:
                 continue
-                            
+
             property_key = (order.utility_property, order.customer)
-            bill_type = self.get_bill_type_for_item(order.utility_service_request, order.item_code)
+            bill_type = self.get_bill_type_for_item(
+                order.utility_service_request, order.item_code
+            )
             if not bill_type:
                 continue
-                            
+
             item_amount = flt(order.base_amount, self.currency_precision)
             self.billing_data[property_key]["ordered"] += item_amount
-            self.billing_data[property_key]["bill_type_ordered"][bill_type] += item_amount
+            self.billing_data[property_key]["bill_type_ordered"][
+                bill_type
+            ] += item_amount
 
     def get_invoiced_qty_for_orders(self):
         sii = frappe.qb.DocType("Sales Invoice Item")
         result = (
             frappe.qb.from_(sii)
-            .select(
-                sii.so_detail,
-                frappe.qb.terms.Function("SUM", sii.qty).as_("qty")
-            )
+            .select(sii.so_detail, frappe.qb.terms.Function("SUM", sii.qty).as_("qty"))
             .where(sii.docstatus == 1)
             .where(sii.so_detail.isnotnull())
             .groupby(sii.so_detail)
@@ -290,8 +337,10 @@ class PropertyBillingOverview:
     def get_bill_type_for_item(self, service_request, item_code):
         if not service_request or not item_code:
             return None
-                    
-        bill_structure = frappe.db.get_value("Utility Service Request", service_request, "utility_bill_structure")
+
+        bill_structure = frappe.db.get_value(
+            "Utility Service Request", service_request, "utility_bill_structure"
+        )
         return self.bill_item_mapping.get(bill_structure, {}).get(item_code)
 
     def get_paid_in_period_by_property(self, property_list, customer_list):
@@ -307,20 +356,20 @@ class PropertyBillingOverview:
 
         query = (
             frappe.qb.from_(ple)
-            .inner_join(acc).on(ple.account == acc.name)
+            .inner_join(acc)
+            .on(ple.account == acc.name)
             .select(
-                ple.party,
-                ple.against_voucher_no,
-                ple.against_voucher_type,
-                ple.amount
+                ple.party, ple.against_voucher_no, ple.against_voucher_type, ple.amount
             )
             .where(ple.party_type == "Customer")
             .where(ple.party.isin(customer_list))
             .where(ple.company == self.filters.company)
-            .where(ple.posting_date.between(self.filters.from_date, self.filters.to_date))
+            .where(
+                ple.posting_date.between(self.filters.from_date, self.filters.to_date)
+            )
             .where(acc.account_type == account_type)
             .where(ple.delinked == 0)
-            .where(ple.amount < 0)  
+            .where(ple.amount < 0)
             .where(ple.against_voucher_type.isin(["Sales Invoice", "Sales Order"]))
         )
 
@@ -335,13 +384,21 @@ class PropertyBillingOverview:
             payment_amount = abs(flt(payment.amount))
 
             if voucher_type == "Sales Invoice":
+                invoice = (
+                    frappe.qb.from_(si)
+                    .select(si.grand_total)
+                    .where(si.name == voucher_no)
+                    .run(as_dict=True)
+                )
+
+                if not invoice:
+                    continue
+
+                total_invoice_amount = flt(invoice[0].grand_total)
+
                 invoice_items = (
                     frappe.qb.from_(sii)
-                    .select(
-                        sii.utility_property,
-                        sii.base_amount,
-                        fn.Sum(sii.base_amount).as_("total_invoice_amount")
-                    )
+                    .select(sii.utility_property, sii.base_amount)
                     .where(sii.parent == voucher_no)
                     .where(sii.docstatus == 1)
                     .where(sii.utility_property.isnotnull())
@@ -350,19 +407,31 @@ class PropertyBillingOverview:
 
                 for prop_data in invoice_items:
                     if prop_data.utility_property in property_list:
-                        proportion = flt(prop_data.base_amount) / flt(prop_data.total_invoice_amount) if prop_data.total_invoice_amount else 1
+                        proportion = (
+                            flt(prop_data.base_amount) / total_invoice_amount
+                            if total_invoice_amount
+                            else 1
+                        )
                         distributed_payment = payment_amount * proportion
                         property_key = (prop_data.utility_property, customer)
                         property_payments[property_key] += distributed_payment
 
             elif voucher_type == "Sales Order":
+                order = (
+                    frappe.qb.from_(so)
+                    .select(so.grand_total)
+                    .where(so.name == voucher_no)
+                    .run(as_dict=True)
+                )
+
+                if not order:
+                    continue
+
+                total_order_amount = flt(order[0].grand_total)
+
                 order_items = (
                     frappe.qb.from_(soi)
-                    .select(
-                        soi.utility_property,
-                        soi.base_amount,
-                        fn.Sum(soi.base_amount).over(partition_by=soi.parent).as_("total_order_amount")
-                    )
+                    .select(soi.utility_property, soi.base_amount)
                     .where(soi.parent == voucher_no)
                     .where(soi.docstatus == 1)
                     .where(soi.utility_property.isnotnull())
@@ -371,7 +440,11 @@ class PropertyBillingOverview:
 
                 for prop_data in order_items:
                     if prop_data.utility_property in property_list:
-                        proportion = flt(prop_data.base_amount) / flt(prop_data.total_order_amount) if prop_data.total_order_amount else 1
+                        proportion = (
+                            flt(prop_data.base_amount) / total_order_amount
+                            if total_order_amount
+                            else 1
+                        )
                         distributed_payment = payment_amount * proportion
                         property_key = (prop_data.utility_property, customer)
                         property_payments[property_key] += distributed_payment
@@ -385,22 +458,24 @@ class PropertyBillingOverview:
                 party_type="Customer",
                 party=customer,
                 date=self.filters.to_date,
-                company=self.filters.company
+                company=self.filters.company,
             )
             for contract in (c for c in self.contracts if c.customer == customer):
-                self.billing_data[(contract.property, contract.customer)]["current_outstanding"] = closing_balance
+                self.billing_data[(contract.property, contract.customer)][
+                    "current_outstanding"
+                ] = closing_balance
 
     def process_data(self):
         self.calculate_customer_totals()
-                
+
         current_customer = None
         for contract in self.contracts:
             property_key = (contract.property, contract.customer)
             billing_info = self.billing_data[property_key]
-                        
-            is_first_row_for_customer = (contract.customer != current_customer)
+
+            is_first_row_for_customer = contract.customer != current_customer
             current_customer = contract.customer
-                        
+
             row = {
                 "property": contract.property,
                 "property_name": contract.property_name,
@@ -413,57 +488,87 @@ class PropertyBillingOverview:
                 "unit_size": contract.unit_size,
                 "customer": contract.customer,
                 "customer_name": contract.customer_name,
-                "contact_number": contract.contact_number if is_first_row_for_customer else "",
+                "contact_number": (
+                    contract.contact_number if is_first_row_for_customer else ""
+                ),
                 "email_id": contract.email_id if is_first_row_for_customer else "",
                 "start_date": contract.start_date,
                 "end_date": contract.end_date,
                 "billing_frequency": contract.billing_frequency,
                 "indent": 1 if not is_first_row_for_customer else 0,
                 "is_group": 0,
-                "parent_customer": contract.customer if not is_first_row_for_customer else "",
-                "opening_arrears": billing_info.get("opening_outstanding", 0) if is_first_row_for_customer else "",
-                "total_paid": billing_info.get("paid", 0),  # Show paid amount for each property/tenancy
-                "current_outstanding_arrears": billing_info.get("current_outstanding", 0) if is_first_row_for_customer else "",
+                "parent_customer": (
+                    contract.customer if not is_first_row_for_customer else ""
+                ),
+                "opening_arrears": (
+                    billing_info.get("opening_outstanding", 0)
+                    if is_first_row_for_customer
+                    else ""
+                ),
+                "total_paid": billing_info.get(
+                    "paid", 0
+                ),  # Show paid amount for each property/tenancy
+                "current_outstanding_arrears": (
+                    billing_info.get("current_outstanding", 0)
+                    if is_first_row_for_customer
+                    else ""
+                ),
                 "total_invoiced": billing_info.get("invoiced", 0),
                 "total_ordered": billing_info.get("ordered", 0),
-                "currency": frappe.get_cached_value('Company', self.filters.company, 'default_currency')
+                "currency": frappe.get_cached_value(
+                    "Company", self.filters.company, "default_currency"
+                ),
             }
-                        
-            self.add_bill_type_data(row, contract, billing_info, is_first_row_for_customer)
+
+            self.add_bill_type_data(
+                row, contract, billing_info, is_first_row_for_customer
+            )
             self.data.append(row)
-               
+
     def calculate_customer_totals(self):
-        self.customer_totals = defaultdict(lambda: {
-            "opening_arrears": 0,
-            "total_paid": 0,
-            "current_outstanding_arrears": 0,
-            "total_invoiced": 0,
-            "total_ordered": 0,
-            "bill_type_invoiced": defaultdict(float),
-            "bill_type_ordered": defaultdict(float)
-        })
+        self.customer_totals = defaultdict(
+            lambda: {
+                "opening_arrears": 0,
+                "total_paid": 0,
+                "current_outstanding_arrears": 0,
+                "total_invoiced": 0,
+                "total_ordered": 0,
+                "bill_type_invoiced": defaultdict(float),
+                "bill_type_ordered": defaultdict(float),
+            }
+        )
 
         for contract in self.contracts:
             property_key = (contract.property, contract.customer)
             billing_info = self.billing_data[property_key]
-                        
+
             customer_data = self.customer_totals[contract.customer]
-            customer_data["opening_arrears"] = billing_info.get("opening_outstanding", 0)
-            customer_data["total_paid"] += billing_info.get("paid", 0)  # Sum payments across properties
-            customer_data["current_outstanding_arrears"] = billing_info.get("current_outstanding", 0)
+            customer_data["opening_arrears"] = billing_info.get(
+                "opening_outstanding", 0
+            )
+            customer_data["total_paid"] += billing_info.get(
+                "paid", 0
+            )  # Sum payments across properties
+            customer_data["current_outstanding_arrears"] = billing_info.get(
+                "current_outstanding", 0
+            )
             customer_data["total_invoiced"] += billing_info.get("invoiced", 0)
             customer_data["total_ordered"] += billing_info.get("ordered", 0)
-                        
+
             for bt in self.bill_types:
                 if bt.name in billing_info["bill_type_invoiced"]:
-                    customer_data["bill_type_invoiced"][bt.name] += billing_info["bill_type_invoiced"][bt.name]
+                    customer_data["bill_type_invoiced"][bt.name] += billing_info[
+                        "bill_type_invoiced"
+                    ][bt.name]
                 if bt.name in billing_info["bill_type_ordered"]:
-                    customer_data["bill_type_ordered"][bt.name] += billing_info["bill_type_ordered"][bt.name]
+                    customer_data["bill_type_ordered"][bt.name] += billing_info[
+                        "bill_type_ordered"
+                    ][bt.name]
 
     def create_customer_total_row(self, customer):
         customer_data = self.customer_totals[customer]
         contract = next(c for c in self.contracts if c.customer == customer)
-                
+
         row = {
             "customer": customer,
             "customer_name": contract.customer_name,
@@ -476,100 +581,253 @@ class PropertyBillingOverview:
             "total_ordered": customer_data["total_ordered"],
             "indent": 0,
             "is_group": 1,
-            "currency": frappe.get_cached_value('Company', self.filters.company, 'default_currency')
+            "currency": frappe.get_cached_value(
+                "Company", self.filters.company, "default_currency"
+            ),
         }
-                
+
         for bt in self.bill_types:
             bill_type_name = scrub(bt.name)
-            row.update({
-                f"{bill_type_name}_invoiced": customer_data["bill_type_invoiced"].get(bt.name, 0),
-                f"{bill_type_name}_ordered": customer_data["bill_type_ordered"].get(bt.name, 0)
-            })
-                
+            row.update(
+                {
+                    f"{bill_type_name}_invoiced": customer_data[
+                        "bill_type_invoiced"
+                    ].get(bt.name, 0),
+                    f"{bill_type_name}_ordered": customer_data["bill_type_ordered"].get(
+                        bt.name, 0
+                    ),
+                }
+            )
+
         return row
 
-    def add_bill_type_data(self, row, contract, billing_info, is_first_row_for_customer):
+    def add_bill_type_data(
+        self, row, contract, billing_info, is_first_row_for_customer
+    ):
         for bt in self.bill_types:
             bill_type_name = scrub(bt.name)
             rate_value = 0
-                        
+
             if contract.utility_bill_structure in self.bill_item_mapping:
                 items_for_bill_type = [
-                    item_code for item_code, item_group in 
-                    self.bill_item_mapping[contract.utility_bill_structure].items() 
+                    item_code
+                    for item_code, item_group in self.bill_item_mapping[
+                        contract.utility_bill_structure
+                    ].items()
                     if item_group == bt.name
                 ]
                 if items_for_bill_type:
                     rate_key = (contract.utility_bill_structure, items_for_bill_type[0])
                     rate_value = self.monthly_rates.get(rate_key, 0)
-                        
-            row.update({
-                f"{bill_type_name}_rate": billing_info["bill_type_rate"].get(bt.name, rate_value),
-                f"{bill_type_name}_invoiced": billing_info["bill_type_invoiced"].get(bt.name, 0),
-                f"{bill_type_name}_ordered": billing_info["bill_type_ordered"].get(bt.name, 0)
-            })
+
+            row.update(
+                {
+                    f"{bill_type_name}_rate": billing_info["bill_type_rate"].get(
+                        bt.name, rate_value
+                    ),
+                    f"{bill_type_name}_invoiced": billing_info[
+                        "bill_type_invoiced"
+                    ].get(bt.name, 0),
+                    f"{bill_type_name}_ordered": billing_info["bill_type_ordered"].get(
+                        bt.name, 0
+                    ),
+                }
+            )
 
     def get_columns(self):
         base_columns = [
-            {"label": _("Customer"), "fieldname": "customer", "fieldtype": "Link", "options": "Customer", "width": 150},
-            {"label": _("Contact"), "fieldname": "contact_number", "fieldtype": "Data", "width": 150},
-            {"label": _("Property"), "fieldname": "property", "fieldtype": "Link", "options": "Utility Property", "width": 150},
-            {"label": _("Unit Size"), "fieldname": "unit_size", "fieldtype": "Float", "width": 150},
-            {"label": _("Lease Start"), "fieldname": "start_date", "fieldtype": "Date", "width": 150},
-            {"label": _("Lease End"), "fieldname": "end_date", "fieldtype": "Date", "width": 150},
-            {"label": _("Opening Arrears"), "fieldname": "opening_arrears", "fieldtype": "Currency", "options": "currency", "width": 150},
-            {"label": _("Paid Amount"), "fieldname": "total_paid", "fieldtype": "Currency", "options": "currency", "width": 150},
-            {"label": _("Outstanding Arrears"), "fieldname": "current_outstanding_arrears", "fieldtype": "Currency", "options": "currency", "width": 150},
+            {
+                "label": _("Customer"),
+                "fieldname": "customer",
+                "fieldtype": "Link",
+                "options": "Customer",
+                "width": 150,
+            },
+            {
+                "label": _("Contact"),
+                "fieldname": "contact_number",
+                "fieldtype": "Data",
+                "width": 150,
+            },
+            {
+                "label": _("Property"),
+                "fieldname": "property",
+                "fieldtype": "Link",
+                "options": "Utility Property",
+                "width": 150,
+            },
+            {
+                "label": _("Unit Size"),
+                "fieldname": "unit_size",
+                "fieldtype": "Float",
+                "width": 150,
+            },
+            {
+                "label": _("Lease Start"),
+                "fieldname": "start_date",
+                "fieldtype": "Date",
+                "width": 150,
+            },
+            {
+                "label": _("Lease End"),
+                "fieldname": "end_date",
+                "fieldtype": "Date",
+                "width": 150,
+            },
+            {
+                "label": _("Opening Arrears"),
+                "fieldname": "opening_arrears",
+                "fieldtype": "Currency",
+                "options": "currency",
+                "width": 150,
+            },
+            {
+                "label": _("Paid Amount"),
+                "fieldname": "total_paid",
+                "fieldtype": "Currency",
+                "options": "currency",
+                "width": 150,
+            },
+            {
+                "label": _("Outstanding Arrears"),
+                "fieldname": "current_outstanding_arrears",
+                "fieldtype": "Currency",
+                "options": "currency",
+                "width": 150,
+            },
         ]
-                
+
         if self.filters.get("show_property_fields"):
-            base_columns.extend([
-                {"label": _("Unit Type"), "fieldname": "unit_type", "fieldtype": "Data", "width": 150},
-                {"label": _("Unit Number"), "fieldname": "unit_number", "fieldtype": "Data", "width": 150},
-                {"label": _("Bedrooms"), "fieldname": "bedrooms", "fieldtype": "Int", "width": 80},
-                {"label": _("Floor Level"), "fieldname": "floor_level", "fieldtype": "Data", "width": 80},
-                {"label": _("Bathrooms"), "fieldname": "bathrooms", "fieldtype": "Int", "width": 80},
-                {"label": _("House No"), "fieldname": "house_no", "fieldtype": "Data", "width": 80},
-            ])
-                
+            base_columns.extend(
+                [
+                    {
+                        "label": _("Unit Type"),
+                        "fieldname": "unit_type",
+                        "fieldtype": "Data",
+                        "width": 150,
+                    },
+                    {
+                        "label": _("Unit Number"),
+                        "fieldname": "unit_number",
+                        "fieldtype": "Data",
+                        "width": 150,
+                    },
+                    {
+                        "label": _("Bedrooms"),
+                        "fieldname": "bedrooms",
+                        "fieldtype": "Int",
+                        "width": 80,
+                    },
+                    {
+                        "label": _("Floor Level"),
+                        "fieldname": "floor_level",
+                        "fieldtype": "Data",
+                        "width": 80,
+                    },
+                    {
+                        "label": _("Bathrooms"),
+                        "fieldname": "bathrooms",
+                        "fieldtype": "Int",
+                        "width": 80,
+                    },
+                    {
+                        "label": _("House No"),
+                        "fieldname": "house_no",
+                        "fieldtype": "Data",
+                        "width": 80,
+                    },
+                ]
+            )
+
         for bt in self.bill_types:
             bill_type_name = scrub(bt.name)
             base_columns.append(
-                {"label": _(f"{bt.name} Rate (Monthly)"), "fieldname": f"{bill_type_name}_rate", "fieldtype": "Currency", "options": "currency", "width": 150}
+                {
+                    "label": _(f"{bt.name} Rate (Monthly)"),
+                    "fieldname": f"{bill_type_name}_rate",
+                    "fieldtype": "Currency",
+                    "options": "currency",
+                    "width": 150,
+                }
             )
-                
+
         for bt in self.bill_types:
             bill_type_name = scrub(bt.name)
             base_columns.append(
-                {"label": _(f"{bt.name} Ordered Amount"), "fieldname": f"{bill_type_name}_ordered", "fieldtype": "Currency", "options": "currency", "width": 150}
+                {
+                    "label": _(f"{bt.name} Ordered Amount"),
+                    "fieldname": f"{bill_type_name}_ordered",
+                    "fieldtype": "Currency",
+                    "options": "currency",
+                    "width": 150,
+                }
             )
-                    
+
         for bt in self.bill_types:
             bill_type_name = scrub(bt.name)
             base_columns.append(
-                {"label": _(f"{bt.name} Invoiced Amount"), "fieldname": f"{bill_type_name}_invoiced", "fieldtype": "Currency", "options": "currency", "width": 150}
+                {
+                    "label": _(f"{bt.name} Invoiced Amount"),
+                    "fieldname": f"{bill_type_name}_invoiced",
+                    "fieldtype": "Currency",
+                    "options": "currency",
+                    "width": 150,
+                }
             )
-                
+
         if self.filters.get("show_totals"):
-            base_columns.extend([
-                {"label": _("Total Invoiced Amount"), "fieldname": "total_invoiced", "fieldtype": "Currency", "options": "currency", "width": 150},
-                {"label": _("Total Ordered Amount"), "fieldname": "total_ordered", "fieldtype": "Currency", "options": "currency", "width": 150},
-            ])
-                
-        base_columns.extend([
-            {"label": _("Indent"), "fieldname": "indent", "fieldtype": "Int", "hidden": 1},
-            {"label": _("Is Group"), "fieldname": "is_group", "fieldtype": "Int", "hidden": 1},
-            {"label": _("Parent Customer"), "fieldname": "parent_customer", "fieldtype": "Data", "hidden": 1}
-        ])
-                
+            base_columns.extend(
+                [
+                    {
+                        "label": _("Total Invoiced Amount"),
+                        "fieldname": "total_invoiced",
+                        "fieldtype": "Currency",
+                        "options": "currency",
+                        "width": 150,
+                    },
+                    {
+                        "label": _("Total Ordered Amount"),
+                        "fieldname": "total_ordered",
+                        "fieldtype": "Currency",
+                        "options": "currency",
+                        "width": 150,
+                    },
+                ]
+            )
+
+        base_columns.extend(
+            [
+                {
+                    "label": _("Indent"),
+                    "fieldname": "indent",
+                    "fieldtype": "Int",
+                    "hidden": 1,
+                },
+                {
+                    "label": _("Is Group"),
+                    "fieldname": "is_group",
+                    "fieldtype": "Int",
+                    "hidden": 1,
+                },
+                {
+                    "label": _("Parent Customer"),
+                    "fieldname": "parent_customer",
+                    "fieldtype": "Data",
+                    "hidden": 1,
+                },
+            ]
+        )
+
         self.columns = base_columns
-            
+
     def clean_columns(self):
         cols_to_remove = set()
 
         for col in self.columns:
             fieldname = col.get("fieldname")
-            if not fieldname or not any(suffix in fieldname for suffix in ["_rate", "_ordered", "_invoiced"]):
+            if not fieldname or not any(
+                suffix in fieldname for suffix in ["_rate", "_ordered", "_invoiced"]
+            ):
                 continue
 
             all_zero = all(
@@ -580,7 +838,9 @@ class PropertyBillingOverview:
             if all_zero:
                 cols_to_remove.add(fieldname)
 
-        self.columns = [col for col in self.columns if col.get("fieldname") not in cols_to_remove]
+        self.columns = [
+            col for col in self.columns if col.get("fieldname") not in cols_to_remove
+        ]
 
         for row in self.data:
             for fieldname in cols_to_remove:


### PR DESCRIPTION
- Updated `get_paid_in_period_by_property` to use `Sales Invoice.grand_total`
  and `Sales Order.grand_total` as the reference amount for payment allocation
- Ensures paid amounts are distributed proportionally against the full voucher
  total instead of per-item totals
- Fixes incorrect allocation when invoices/orders have multiple items