### PR TITLE
fix(company): improve abbreviation generation and creation robustness

### DIFF
--- a/utility_billing/utility_billing/patches/demo/company.py
+++ b/utility_billing/utility_billing/patches/demo/company.py
@@ -8,33 +8,51 @@ COMPANY_NAME: Optional[str] = None
 COMPANY_ABBR: Optional[str] = None
 
 
+def get_unique_abbr(base_abbr: str) -> str:
+    """Generate a unique company abbreviation."""
+    if not frappe.db.exists("Company", {"abbr": base_abbr}):
+        return base_abbr
+
+    i = 1
+    while True:
+        new_abbr = f"{base_abbr}-{i}"
+        if not frappe.db.exists("Company", {"abbr": new_abbr}):
+            return new_abbr
+        i += 1
+
+
 def create_sample_company() -> None:
     """
     Create a sample company from JSON configuration.
     Handles case where company.json contains a list and picks the first entry.
-    
-    Returns:
-        None
+    Automatically generates a new abbr if a conflict exists.
     """
     global COMPANY_NAME, COMPANY_ABBR
 
     data = safe_load_json("data/company.json")
-    
-    # Handle case where data is a list
+
     if isinstance(data, list) and data:
         company_data = data[0]
     else:
         company_data = data
 
     COMPANY_NAME = company_data.get("company_name")
-    COMPANY_ABBR = company_data.get("abbr")
+    base_abbr = company_data.get("abbr")
 
-    if not COMPANY_NAME or frappe.db.exists("Company", COMPANY_NAME):
+    if not COMPANY_NAME or not base_abbr:
+        logger.error("Company name or abbr missing in company.json")
         return
+
+    if frappe.db.exists("Company", {"company_name": COMPANY_NAME}):
+        logger.info(f"Company {COMPANY_NAME} already exists, skipping.")
+        return
+
+    COMPANY_ABBR = get_unique_abbr(base_abbr)
+    company_data["abbr"] = COMPANY_ABBR
 
     try:
         company = frappe.get_doc({"doctype": "Company", **company_data})
-        company.insert()
-        logger.info(f"Company {COMPANY_NAME} created successfully.")
+        company.insert(ignore_permissions=True)
+        logger.info(f"Company {COMPANY_NAME} created with abbr {COMPANY_ABBR}.")
     except Exception:
         logger.exception("Error creating company")


### PR DESCRIPTION
Enhance the company creation process with conflict resolution for abbreviations and improved validation safeguards.

- Implement iterative suffixing (e.g., 'CMP-1', 'CMP-2') to ensure
  unique company abbreviations.
- Add existence checks to skip creation if a company name is already present.
- Enforce mandatory presence of company name and abbreviation before insert.
- Use `ignore_permissions` during insertion to ensure setup flow completes.
- Add comprehensive logging for successful creation and skip scenarios.