### PR TITLE
chore: improve sample company creation and demo data coverage

### DIFF
--- a/utility_billing/hooks.py
+++ b/utility_billing/hooks.py
@@ -140,6 +140,7 @@ utility_demo_master_doctypes = [
     "item_price",
     "location",
     "serial_no",
+    "uom",
     "utility_property_feature_type",
     "utility_property_feature",
     "utility_property_unit_type",

--- a/utility_billing/utility_billing/patches/demo/company.py
+++ b/utility_billing/utility_billing/patches/demo/company.py
@@ -8,33 +8,51 @@ COMPANY_NAME: Optional[str] = None
 COMPANY_ABBR: Optional[str] = None
 
 
+def get_unique_abbr(base_abbr: str) -> str:
+    """Generate a unique company abbreviation."""
+    if not frappe.db.exists("Company", {"abbr": base_abbr}):
+        return base_abbr
+
+    i = 1
+    while True:
+        new_abbr = f"{base_abbr}-{i}"
+        if not frappe.db.exists("Company", {"abbr": new_abbr}):
+            return new_abbr
+        i += 1
+
+
 def create_sample_company() -> None:
     """
     Create a sample company from JSON configuration.
     Handles case where company.json contains a list and picks the first entry.
-    
-    Returns:
-        None
+    Automatically generates a new abbr if a conflict exists.
     """
     global COMPANY_NAME, COMPANY_ABBR
 
     data = safe_load_json("data/company.json")
-    
-    # Handle case where data is a list
+
     if isinstance(data, list) and data:
         company_data = data[0]
     else:
         company_data = data
 
     COMPANY_NAME = company_data.get("company_name")
-    COMPANY_ABBR = company_data.get("abbr")
+    base_abbr = company_data.get("abbr")
 
-    if not COMPANY_NAME or frappe.db.exists("Company", COMPANY_NAME):
+    if not COMPANY_NAME or not base_abbr:
+        logger.error("Company name or abbr missing in company.json")
         return
+
+    if frappe.db.exists("Company", {"company_name": COMPANY_NAME}):
+        logger.info(f"Company {COMPANY_NAME} already exists, skipping.")
+        return
+
+    COMPANY_ABBR = get_unique_abbr(base_abbr)
+    company_data["abbr"] = COMPANY_ABBR
 
     try:
         company = frappe.get_doc({"doctype": "Company", **company_data})
-        company.insert()
-        logger.info(f"Company {COMPANY_NAME} created successfully.")
+        company.insert(ignore_permissions=True)
+        logger.info(f"Company {COMPANY_NAME} created with abbr {COMPANY_ABBR}.")
     except Exception:
         logger.exception("Error creating company")

--- a/utility_billing/utility_billing/patches/demo/data/item_group.json
+++ b/utility_billing/utility_billing/patches/demo/data/item_group.json
@@ -3,5 +3,15 @@
     "item_group_name": "Utilities",
     "is_utility_item_group": 1,
     "doctype": "Item Group"
+  },
+  {
+    "item_group_name": "Fixed Asset",
+    "is_utility_item_group": 0,
+    "doctype": "Item Group"
+  },
+  {
+    "item_group_name": "Meter",
+    "is_utility_item_group": 1,
+    "doctype": "Item Group"
   }
 ]

--- a/utility_billing/utility_billing/patches/demo/data/uom.json
+++ b/utility_billing/utility_billing/patches/demo/data/uom.json
@@ -1,0 +1,7 @@
+[
+  {
+    "uom_name": "Unit",
+    "enabled": 1,
+    "doctype": "UOM"
+  }
+]


### PR DESCRIPTION
This pull request introduces improvements to the sample company creation process, enhances demo data coverage, and updates the hook configuration for utility billing. The most important changes include making company abbreviation generation conflict-free, expanding demo data for item groups and units of measure, and ensuring the `uom` field is included in the hooks.

**Sample Company Creation Improvements:**
* Added a `get_unique_abbr` function to generate a unique company abbreviation if a conflict exists, and updated `create_sample_company` to use it and improve error handling and logging.

**Demo Data Enhancements:**
* Expanded `item_group.json` demo data to include "Fixed Asset" and "Meter" item groups for more comprehensive testing and setup.
* Added a new `uom.json` demo data file to provide a default "Unit" UOM for demo environments.

**Configuration Updates:**
* Added the `uom` field to the list of exported fields in `hooks.py` to ensure it is included in relevant operations.